### PR TITLE
fix: MatchmealApplicationTests class name change

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/matchmeal.main.iml" filepath="$PROJECT_DIR$/.idea/modules/matchmeal.main.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/matchmeal.main.iml
+++ b/.idea/modules/matchmeal.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ tasks.register('integrationTest', Test) {
     classpath = sourceSets.test.runtimeClasspath
 
     // IntegrationTest로 끝나는 것만 '포함'
-    includ '**/*IntegrationTest.class'
+    include '**/*IntegrationTest.class'
 
     // 단위 테스트 먼저 돌고, 통합테스크가 돌도록 순서 지정
     shouldRunAfter tasks.named('test')

--- a/src/test/java/com/pagoda/matchmeal/MatchmealApplicationIntegrationTest.java
+++ b/src/test/java/com/pagoda/matchmeal/MatchmealApplicationIntegrationTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class MatchmealApplicationTests {
+class MatchmealApplicationIntegrationTest {
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
단위 테스트 실패 해결
원인 : 뒤에 IntegrationTest 이름이 붙은 클래스만 SpringBootTest 가 동작되도록 설정되어있는데 MatchmealApplicationTests 이름의 클래스 파일이 존재
해결 : MatchmealApplicationTests 클래스 이름을 MatchmealApplicationIntegrationTest로 수정