### PR TITLE
Feature/mattermost 알림 연동 구현

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -1,0 +1,53 @@
+name: PR Review Notification
+
+# PR이 '생성(opened)'되거나, '다시 열림(reopened)',
+# 혹은 초안에서 '리뷰 가능(ready_for_review)' 상태로 바뀌었을 때만 실행
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    branches: [ "develop", "main" ] # 두 브랜치 모두 감시
+
+jobs:
+  notify-mattermost:
+    # Draft(초안) 상태인 PR은 알림을 보내지 않음
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Review Request to Mattermost
+        run: |
+          curl -i -X POST \
+          -H 'Content-Type: application/json' \
+          -d '{
+            "username": "Pagoda-Bot",
+            "icon_url": "https://cdn-icons-png.flaticon.com/512/1055/1055687.png",
+            "text": "#### :loudspeaker: 리뷰 요청이 도착했습니다!",
+            "attachments": [
+              {
+                "color": "#2f81f7", 
+                "pretext": "새로운 PR이 **${{ github.base_ref }}** 브랜치로 요청되었습니다.",
+                "title": "${{ github.event.pull_request.title }} (#${{ github.event.number }})",
+                "title_link": "${{ github.event.pull_request.html_url }}",
+                "fields": [
+                  {
+                    "short": true,
+                    "title": "작성자",
+                    "value": "${{ github.event.pull_request.user.login }}"
+                  },
+                  {
+                    "short": true,
+                    "title": "타겟 브랜치",
+                    "value": "`${{ github.event.pull_request.base.ref }}`"
+                  },
+                  {
+                    "short": false,
+                    "title": "변경 사항 요약",
+                    "value": "클릭하여 GitHub에서 상세 내용을 확인해주세요."
+                  }
+                ],
+                "footer": "GitHub Actions",
+                "footer_icon": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+              }
+            ]
+          }' \
+          ${{ secrets.MATTERMOST_WEBHOOK_URL }}


### PR DESCRIPTION
## 📌 변경 사항
- **PR 알림 워크플로우 추가**: `.github/workflows/pr-notification.yml`
- **Mattermost 연동**: PR 생성 및 리뷰 요청 시 '탑골공원' 채널로 알림 발송

## 💡 도입 목적
- PR 생성 시 팀원들에게 자동으로 알림을 보내 빠른 코드 리뷰 유도
- 매번 링크를 복사해서 메신저에 공유하는 번거로움 제거

## ⚙️ 동작 로직
- **Trigger**: `develop`, `main` 브랜치로 PR 생성(opened) / 재오픈(reopened) / 리뷰 전환(ready_for_review) 시
- **Filter**: **Draft(초안)** 상태일 경우 알림 미발송 (Ready 상태일 때만 발송)
- **Bot Info**: `Pagoda-Bot` (기와집 아이콘 적용)

## ✅ 체크리스트
- [x] Repository Secrets에 `MATTERMOST_WEBHOOK_URL` 등록 완료
- [x] Draft PR 생성 시 알림이 오지 않는지 확인
- [x] PR을 Open 하거나 Ready로 변경 시 알림이 정상 도착하는지 확인