### PR TITLE
fix: 디렉토리명 일관성을 위한 네이밍 변경

### DIFF
--- a/src/main/java/com/pagoda/matchmeal/common/config/FoodBatchConfig.java
+++ b/src/main/java/com/pagoda/matchmeal/common/config/FoodBatchConfig.java
@@ -1,6 +1,6 @@
 package com.pagoda.matchmeal.common.config;
 
-import com.pagoda.matchmeal.model.Entity.Food;
+import com.pagoda.matchmeal.model.entity.Food;
 import com.pagoda.matchmeal.model.dto.FoodCsvDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/pagoda/matchmeal/mapper/FoodBatchMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/FoodBatchMapper.java
@@ -1,6 +1,6 @@
 package com.pagoda.matchmeal.mapper;
 
-import com.pagoda.matchmeal.model.Entity.Food;
+import com.pagoda.matchmeal.model.entity.Food;
 
 import java.util.List;
 

--- a/src/main/java/com/pagoda/matchmeal/model/entity/Food.java
+++ b/src/main/java/com/pagoda/matchmeal/model/entity/Food.java
@@ -1,4 +1,4 @@
-package com.pagoda.matchmeal.model.Entity;
+package com.pagoda.matchmeal.model.entity;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/resources/mappers/FoodBatchMapper.xml
+++ b/src/main/resources/mappers/FoodBatchMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.pagoda.matchmeal.mapper.FoodBatchMapper">
-    <insert id="insertFood" parameterType="com.pagoda.matchmeal.model.Entity.Food">
+    <insert id="insertFood" parameterType="com.pagoda.matchmeal.model.entity.Food">
         INSERT INTO foods (food_code,
                            food_name,
                            category,
@@ -39,6 +39,6 @@
         SELECT COUNT(*) FROM foods
     </select>
 
-    <select id="findAll" resultType="com.pagoda.matchmeal.model.Entity.Food">
+    <select id="findAll" resultType="com.pagoda.matchmeal.model.entity.Food">
         SELECT * FROM foods LIMIT 50  </select>
 </mapper>

--- a/src/test/java/com/pagoda/matchmeal/FoodImportJobTest.java
+++ b/src/test/java/com/pagoda/matchmeal/FoodImportJobTest.java
@@ -1,8 +1,7 @@
 package com.pagoda.matchmeal;
 
 import com.pagoda.matchmeal.mapper.FoodBatchMapper;
-import com.pagoda.matchmeal.model.Entity.Food;
-import org.junit.jupiter.api.Assertions;
+import com.pagoda.matchmeal.model.entity.Food;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.Job;
@@ -11,7 +10,6 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 


### PR DESCRIPTION
model 하위에 엔티티 객체를 담고 있던 디렉토리명이 Entity로 되어있어 entity로 다른 디렉토리명과 일관성을 맞추기 위해 변경했습니다.
그에 따른 Food.java 의 참조위치명도 바뀌어 Food를 참조하는 객체들의 수정사항이 발생했습니다.