### PR TITLE
Feat/Fix: 챌린지 초대/나가기 기능 구현 및 식단 연동 진척도 로직 고도화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+//    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/pagoda/matchmeal/common/exception/ErrorResponseCode.java
+++ b/src/main/java/com/pagoda/matchmeal/common/exception/ErrorResponseCode.java
@@ -36,9 +36,13 @@ public enum ErrorResponseCode {
     ALREADY_JOINED_CHALLENGE(HttpStatus.BAD_REQUEST, "이미 참여중인 챌린지입니다."),
     ALREADY_INVITED(HttpStatus.CONFLICT, "이미 초대를 보낸 사용자입니다."),
     ALREADY_JOINED_USER(HttpStatus.CONFLICT, "이미 챌린지에 참여 중인 사용자입니다."),
+    NOT_JOINED_USER(HttpStatus.NOT_FOUND, "참여중인 대상이 아닙니다."),
     CHALLENGE_FULL(HttpStatus.BAD_REQUEST, "챌린지 정원이 가득 찼습니다."),
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 챌린지를 찾을 수 없습니다."),
     NOT_FOLLOWING(HttpStatus.NOT_FOUND, "팔로우중이 아닙니다."),
+    OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "소유자는 나갈 수 없습니다."),
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "초대장을 찾을 수 없습니다."),
+    ALREADY_PROCESSED_INVITATION(HttpStatus.BAD_REQUEST, "이미 처리된 초대장입니다."),
 
     //----------------------------게시글 에러코드----------------------------
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/pagoda/matchmeal/controller/AiController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/AiController.java
@@ -1,0 +1,7 @@
+package com.pagoda.matchmeal.controller;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class AiController {
+}

--- a/src/main/java/com/pagoda/matchmeal/controller/ChallengeController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/ChallengeController.java
@@ -129,4 +129,17 @@ public class ChallengeController {
 
         return ApiResponseUtil.success();
     }
+
+    /**
+     * 챌린지 삭제
+     */
+    @DeleteMapping("/{challengeId}")
+    public CommonResponse<Void> deleteChallenge(
+            @AuthenticationPrincipal UserDto user,
+            @PathVariable Long challengeId) {
+
+        challengeService.deleteChallenge(user.getId(), challengeId);
+
+        return ApiResponseUtil.success();
+    }
 }

--- a/src/main/java/com/pagoda/matchmeal/controller/ChallengeController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/ChallengeController.java
@@ -6,6 +6,7 @@ import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.UserDto;
 import com.pagoda.matchmeal.model.dto.request.ChallengeCreateRequestDto;
 import com.pagoda.matchmeal.model.dto.request.ChallengeInviteRequestDto;
+import com.pagoda.matchmeal.model.dto.response.ChallengeInvitationResponseDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
 import com.pagoda.matchmeal.service.ChallengeService;
 import lombok.RequiredArgsConstructor;
@@ -177,6 +178,16 @@ public class ChallengeController {
 
         challengeService.respondInvitation(user.getId(), invitationId, false);
         return ApiResponseUtil.success();
+    }
+
+    /**
+     * 나에게 온 초대장 목록 조회
+     */
+    @GetMapping("/invitations")
+    public CommonResponse<List<ChallengeInvitationResponseDto>> getMyInvitations(
+            @AuthenticationPrincipal UserDto user) {
+
+        return ApiResponseUtil.success(challengeService.getMyInvitations(user.getId()));
     }
 
 }

--- a/src/main/java/com/pagoda/matchmeal/controller/ChallengeController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/ChallengeController.java
@@ -150,7 +150,7 @@ public class ChallengeController {
     @PostMapping("/{challengeId}/leave")
     public CommonResponse<Void> leaveChallenge(
             @AuthenticationPrincipal UserDto user,
-            @PathVariable Long challengeid) {
+            @PathVariable("challengeId") Long challengeid) {
 
         challengeService.leaveChallenge(user.getId(), challengeid);
         return ApiResponseUtil.success();

--- a/src/main/java/com/pagoda/matchmeal/controller/ChallengeController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/ChallengeController.java
@@ -142,4 +142,41 @@ public class ChallengeController {
 
         return ApiResponseUtil.success();
     }
+
+    /**
+     * 챌린지 떠나기
+     */
+    @PostMapping("/{challengeId}/leave")
+    public CommonResponse<Void> leaveChallenge(
+            @AuthenticationPrincipal UserDto user,
+            @PathVariable Long challengeid) {
+
+        challengeService.leaveChallenge(user.getId(), challengeid);
+        return ApiResponseUtil.success();
+    }
+
+    /**
+     * 초대 승인
+     */
+    @PostMapping("invite/{invitationId}/accept")
+    public CommonResponse<Void> acceptInvitation(
+            @AuthenticationPrincipal UserDto user,
+            @PathVariable Long invitationId) {
+
+        challengeService.respondInvitation(user.getId(), invitationId, true);
+        return ApiResponseUtil.success();
+    }
+
+    /**
+     * 초대 거절
+     */
+    @PostMapping("invite/{invitationId}/reject")
+    public CommonResponse<Void> rejectInvitation(
+            @AuthenticationPrincipal UserDto user,
+            @PathVariable Long invitationId) {
+
+        challengeService.respondInvitation(user.getId(), invitationId, false);
+        return ApiResponseUtil.success();
+    }
+
 }

--- a/src/main/java/com/pagoda/matchmeal/controller/DietController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/DietController.java
@@ -77,4 +77,21 @@ public class DietController {
 
         return ApiResponseUtil.success(dietService.getDietStats(searchUserId, dietStatsRequestDto));
     }
+
+    /**
+     * [기간 조회] 챌린지 기간 등 특정 기간의 식단 기록 조회
+     * - 본인 또는 타인의 식단 기록을 기간 단위로 조회
+     */
+    @GetMapping("/diet/period")
+    public CommonResponse<List<DietResponseDto>> getDietListByPeriod(
+            @AuthenticationPrincipal UserDto userDto,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(value = "userId", required = false) Long targetUserId) {
+
+        // targetUserId가 있으면 그 유저를, 없으면 로그인한 유저 본인을 조회
+        Long searchUserId = (targetUserId != null) ? targetUserId : userDto.getId();
+
+        return ApiResponseUtil.success(dietService.getDietListByPeriod(searchUserId, startDate, endDate));
+    }
 }

--- a/src/main/java/com/pagoda/matchmeal/controller/DietController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/DietController.java
@@ -32,13 +32,19 @@ public class DietController {
     }
 
     @GetMapping("/diet")
-    public CommonResponse<List<DietResponseDto>> getDailyDiet(@AuthenticationPrincipal UserDto userDto,
-                                                              @RequestParam(value = "date", required = false)
-                                                              @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+    public CommonResponse<List<DietResponseDto>> getDailyDiet(
+            @AuthenticationPrincipal UserDto userDto,
+            @RequestParam(value = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(value = "userId", required = false) Long targetUserId) { // [추가]
+
         if (date == null) {
             date = LocalDate.now();
         }
-        return ApiResponseUtil.success(dietService.getDailyDiet(userDto.getId(), date));
+
+        // 타겟 ID가 있으면 그 사람 것을, 없으면 내 것을 조회
+        Long searchUserId = (targetUserId != null) ? targetUserId : userDto.getId();
+
+        return ApiResponseUtil.success(dietService.getDailyDiet(searchUserId, date));
     }
 
     @GetMapping("/diet/{dietId}")
@@ -64,8 +70,11 @@ public class DietController {
     @GetMapping("/diet/stats")
     public CommonResponse<DietStatsResponseDto> getDietStats(
             @AuthenticationPrincipal UserDto userDto,
-            @ModelAttribute DietStatsRequestDto dietStatsRequestDto
-    ) {
-        return ApiResponseUtil.success(dietService.getDietStats(userDto.getId(), dietStatsRequestDto));
+            @ModelAttribute DietStatsRequestDto dietStatsRequestDto,
+            @RequestParam(value = "userId", required = false) Long targetUserId) { // [추가]
+
+        Long searchUserId = (targetUserId != null) ? targetUserId : userDto.getId();
+
+        return ApiResponseUtil.success(dietService.getDietStats(searchUserId, dietStatsRequestDto));
     }
 }

--- a/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
@@ -2,6 +2,7 @@ package com.pagoda.matchmeal.mapper;
 
 import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
+import com.pagoda.matchmeal.model.dto.response.ChallengeParticipantDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
 import com.pagoda.matchmeal.model.entity.Challenge;
 import org.apache.ibatis.annotations.Mapper;
@@ -118,4 +119,13 @@ public interface ChallengeMapper {
      * @param challenge
      */
     void updateChallenge(Challenge challenge);
+
+    /**
+     * 특정 챌린지의 참여자 목록 조회
+     * @param challengeId
+     * @return 참여자 정보를 담은 리스트 반환
+     */
+    List<ChallengeParticipantDto> findParticipantsByChallengeId(Long challengeId);
+
+    void increaseHeadCount(Long challengeId);
 }

--- a/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
@@ -2,6 +2,7 @@ package com.pagoda.matchmeal.mapper;
 
 import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
+import com.pagoda.matchmeal.model.dto.response.ChallengeInvitationResponseDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeParticipantDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
 import com.pagoda.matchmeal.model.entity.Challenge;
@@ -171,6 +172,11 @@ public interface ChallengeMapper {
      * @return 챌린지 초대 정보
      */
     ChallengeInvitation findInvitationById(Long invitationId);
+
+    /**
+     * 나에게 온 대기 중인 초대장 목록 조회
+     */
+    List<ChallengeInvitationResponseDto> findPendingInvitationsByUserId(Long userId);
 
     /**
      * 초대장 상태 업데이트

--- a/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
@@ -5,6 +5,7 @@ import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeParticipantDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
 import com.pagoda.matchmeal.model.entity.Challenge;
+import com.pagoda.matchmeal.model.entity.ChallengeInvitation;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -150,4 +151,31 @@ public interface ChallengeMapper {
      * @param challengeId
      */
     void deleteChallengeById(Long challengeId);
+
+    /**
+     * 유저 챌린지 기록 삭제 (나가기)
+     * @param userId
+     * @param challengeId
+     */
+    void deleteUserChallenge(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
+
+    /**
+     * 챌린지 인원수 감소
+     * @param challengeId
+     */
+    void decreaseHeadCount(Long challengeId);
+    
+    /**
+     * 초대장 조회 (ID)
+     * @param invitationId
+     * @return 챌린지 초대 정보
+     */
+    ChallengeInvitation findInvitationById(Long invitationId);
+
+    /**
+     * 초대장 상태 업데이트
+     * @param invitationId
+     * @param status (ACCEPTED / REJECTED)
+     */
+    void updateInvitationStatus(@Param("invitationId") Long invitationId, @Param("status") String status);
 }

--- a/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
@@ -184,4 +184,6 @@ public interface ChallengeMapper {
      * @param status (ACCEPTED / REJECTED)
      */
     void updateInvitationStatus(@Param("invitationId") Long invitationId, @Param("status") String status);
+
+    void updateStatusToProgress(Long userChallengeId);
 }

--- a/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/ChallengeMapper.java
@@ -127,5 +127,27 @@ public interface ChallengeMapper {
      */
     List<ChallengeParticipantDto> findParticipantsByChallengeId(Long challengeId);
 
+    /**
+     * 챌린지 최대 인원
+     * @param challengeId
+     */
     void increaseHeadCount(Long challengeId);
+
+    /**
+     * 해당 챌린지의 모든 초대장 삭제
+     * @param challengeId
+     */
+    void deleteInvitationsByChallengeId(Long challengeId);
+
+    /**
+     * 해당 챌린지의 모든 참여 기록 삭제
+     * @param challengeId
+     */
+    void deleteUserChallengesByChallengeId(Long challengeId);
+
+    /**
+     * 챌린지 본체 삭제
+     * @param challengeId
+     */
+    void deleteChallengeById(Long challengeId);
 }

--- a/src/main/java/com/pagoda/matchmeal/mapper/DietMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/DietMapper.java
@@ -71,4 +71,18 @@ public interface DietMapper {
     List<DailyDietStatDto> getDailyDietStats(@Param("userId") Long userId,
                                              @Param("startDate") LocalDate startDate,
                                              @Param("endDate") LocalDate endDate);
+
+//    /**
+//     * 특정 날짜의 식단 목록을 조회합니다. (기간 조회)
+//     *
+//     * @param userId
+//     * @param startDate
+//     * @param endDate
+//     * @return 해당 기간의 식단 리스트
+//     */
+//    List<DietResponseDto> findAllByPeriod(
+//            @Param("userId") Long userId,
+//            @Param("startDate") String startDate,
+//            @Param("endDate") String endDate
+//    );
 }

--- a/src/main/java/com/pagoda/matchmeal/mapper/DietMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/DietMapper.java
@@ -72,17 +72,13 @@ public interface DietMapper {
                                              @Param("startDate") LocalDate startDate,
                                              @Param("endDate") LocalDate endDate);
 
-//    /**
-//     * 특정 날짜의 식단 목록을 조회합니다. (기간 조회)
-//     *
-//     * @param userId
-//     * @param startDate
-//     * @param endDate
-//     * @return 해당 기간의 식단 리스트
-//     */
-//    List<DietResponseDto> findAllByPeriod(
-//            @Param("userId") Long userId,
-//            @Param("startDate") String startDate,
-//            @Param("endDate") String endDate
-//    );
+    /**
+     * 특정 기간의 식단 목록을 조회합니다. (기간 조회)
+     * - 챌린지 상세 화면에서 특정 유저의 기록을 볼 때 사용
+     */
+    List<DietResponseDto> findAllByPeriod(
+            @Param("userId") Long userId,
+            @Param("startDate") String startDate,
+            @Param("endDate") String endDate
+    );
 }

--- a/src/main/java/com/pagoda/matchmeal/model/dto/response/ActiveChallengeDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/response/ActiveChallengeDto.java
@@ -18,7 +18,12 @@ public class ActiveChallengeDto {
     private int maxStreak;
     private LocalDate lastSuccessDate;
 
+    private String status;
+
     // challenges 테이블 정보 (JOIN 데이터)
+    private Long challengeId;
+    private String title;
+
     private ChallengeType type;
     private int targetValue;
     private LocalDate startDate;

--- a/src/main/java/com/pagoda/matchmeal/model/dto/response/ChallengeInvitationResponseDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/response/ChallengeInvitationResponseDto.java
@@ -1,0 +1,31 @@
+package com.pagoda.matchmeal.model.dto.response;
+
+import com.pagoda.matchmeal.model.enums.ChallengeType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeInvitationResponseDto {
+    // 초대 정보
+    private Long invitationId;
+    private LocalDateTime sentAt; // 보낸 시간 (createdAt)
+
+    // 보낸 사람 (Inviter) 정보
+    private Long inviterId;
+    private String inviterName;
+    private String inviterProfileImage;
+
+    // 챌린지 정보
+    private Long challengeId;
+    private String challengeTitle;
+    private ChallengeType type;
+    private int targetValue;
+    private int goalCount;
+    private int currentHeadCount;
+    private int maxParticipants;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/response/ChallengeParticipantDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/response/ChallengeParticipantDto.java
@@ -1,0 +1,15 @@
+package com.pagoda.matchmeal.model.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ChallengeParticipantDto {
+    private Long userId;
+    private String userName;
+    private String profileImage;
+    private int progressPercent;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/response/ChallengeResponseDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/response/ChallengeResponseDto.java
@@ -5,6 +5,7 @@ import com.pagoda.matchmeal.model.enums.ChallengeType;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Setter
@@ -22,6 +23,10 @@ public class ChallengeResponseDto {
     private LocalDate startDate;
     private LocalDate endDate;
     private int goalCount; // 목표 횟수
+
+    // 인원 현황
+    private int currentHeadCount;
+    private int maxParticipants;
     
     // 유저별 진행상황
     private Long userChallengeId;
@@ -36,4 +41,6 @@ public class ChallengeResponseDto {
     private int progressPercent; // 현재 달성 횟수
 
     private LocalDate lastSuccessDate;
+
+    private List<ChallengeParticipantDto> participants;
 }

--- a/src/main/java/com/pagoda/matchmeal/service/AiService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/AiService.java
@@ -1,0 +1,7 @@
+package com.pagoda.matchmeal.service;
+
+import java.time.LocalDate;
+
+public interface AiService {
+    String getPeriodFeedback(Long userId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/pagoda/matchmeal/service/ChallengeService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/ChallengeService.java
@@ -47,9 +47,18 @@ public interface ChallengeService {
      */
     List<ChallengeResponseDto> getAllChallenges(Long userId);
 
-    // 상세 조회
+    /**
+     * 상세 조회
+     */
     ChallengeResponseDto getChallengeDetail(Long userId, Long challengeId);
 
-    // 챌린지 수정
+    /**
+     * 챌린지 수정
+     */
     void updateChallenge(Long userId, Long challengeId, ChallengeCreateRequestDto dto);
+
+    /**
+     * 챌린지 삭제
+     */
+    void deleteChallenge(Long userId, Long challengeId);
 }

--- a/src/main/java/com/pagoda/matchmeal/service/ChallengeService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/ChallengeService.java
@@ -2,10 +2,12 @@ package com.pagoda.matchmeal.service;
 
 import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.request.ChallengeCreateRequestDto;
+import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
 import com.pagoda.matchmeal.model.entity.Diet;
 import com.pagoda.matchmeal.model.entity.DietDetail;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ChallengeService {
@@ -61,4 +63,21 @@ public interface ChallengeService {
      * 챌린지 삭제
      */
     void deleteChallenge(Long userId, Long challengeId);
+
+    /**
+     * 챌린지 떠나기
+     * @param userId
+     * @param challengeId
+     */
+    void leaveChallenge(Long userId, Long challengeId);
+
+    /**
+     * 초대 응답(수락, 거부)
+      * @param userId
+     * @param invitationId
+     * @param isAccepted
+     */    
+    void respondInvitation(Long userId, Long invitationId, boolean isAccepted);
+
+
 }

--- a/src/main/java/com/pagoda/matchmeal/service/ChallengeService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/ChallengeService.java
@@ -3,6 +3,7 @@ package com.pagoda.matchmeal.service;
 import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.request.ChallengeCreateRequestDto;
 import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
+import com.pagoda.matchmeal.model.dto.response.ChallengeInvitationResponseDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
 import com.pagoda.matchmeal.model.entity.Diet;
 import com.pagoda.matchmeal.model.entity.DietDetail;
@@ -79,5 +80,11 @@ public interface ChallengeService {
      */    
     void respondInvitation(Long userId, Long invitationId, boolean isAccepted);
 
+    /**
+     * 초대받은 챌린지 관리
+     * @param userId
+     * @return 초대받은 챌린지 정보 리스트
+     */
+    List<ChallengeInvitationResponseDto> getMyInvitations(Long userId);
 
 }

--- a/src/main/java/com/pagoda/matchmeal/service/DietService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/DietService.java
@@ -22,4 +22,6 @@ public interface DietService {
     void deleteDiet(Long userId, Long dietId);
 
     DietStatsResponseDto getDietStats(Long userId, DietStatsRequestDto dietStatsRequestDto);
+
+    List<DietResponseDto> getDietListByPeriod(Long userId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/pagoda/matchmeal/service/impl/AiServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/AiServiceImpl.java
@@ -1,0 +1,14 @@
+package com.pagoda.matchmeal.service.impl;
+
+import com.pagoda.matchmeal.service.AiService;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+public class AiServiceImpl implements AiService {
+    @Override
+    public String getPeriodFeedback(Long userId, LocalDate startDate, LocalDate endDate) {
+        return "";
+    }
+}

--- a/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
@@ -6,6 +6,7 @@ import com.pagoda.matchmeal.mapper.ChallengeMapper;
 import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.request.ChallengeCreateRequestDto;
 import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
+import com.pagoda.matchmeal.model.dto.response.ChallengeParticipantDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
 import com.pagoda.matchmeal.model.entity.Challenge;
 import com.pagoda.matchmeal.model.entity.Diet;
@@ -104,6 +105,9 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         // 참여
         challengeMapper.insertUserChallenge(userId, challenge.getChallengeId());
+
+        // 챌린지 테이블의 참여 인원수 증가
+        challengeMapper.increaseHeadCount(challenge.getChallengeId());
     }
 
     /**
@@ -285,8 +289,17 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Override
     @Transactional(readOnly = true)
     public ChallengeResponseDto getChallengeDetail(Long userId, Long challengeId) {
-        return challengeMapper.findChallengeDetailById(userId, challengeId)
+        // 챌린지 기본 정보 + 내 진행 상황 조회
+        ChallengeResponseDto response = challengeMapper.findChallengeDetailById(userId, challengeId)
                 .orElseThrow(() -> new CustomException(ErrorResponseCode.CHALLENGE_NOT_FOUND));
+
+        // 해당 챌린지의 참여자 목록 조회 및 세팅
+        List<ChallengeParticipantDto> participants = challengeMapper.findParticipantsByChallengeId(challengeId);
+        response.setParticipants(participants);
+
+        // 리스트 화면과 싱크를 맞추기 위해 headCount도 다시 세팅
+        response.setCurrentHeadCount(participants.size());
+        return response;
     }
 
     @Override

--- a/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
@@ -6,6 +6,7 @@ import com.pagoda.matchmeal.mapper.ChallengeMapper;
 import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.request.ChallengeCreateRequestDto;
 import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
+import com.pagoda.matchmeal.model.dto.response.ChallengeInvitationResponseDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeParticipantDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
 import com.pagoda.matchmeal.model.entity.Challenge;
@@ -417,5 +418,14 @@ public class ChallengeServiceImpl implements ChallengeService {
             // 거절
             challengeMapper.updateInvitationStatus(invitationId, "REJECTED");
         }
+    }
+
+    /**
+     * 나에게 온 초대장 목록 조회
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChallengeInvitationResponseDto> getMyInvitations(Long userId) {
+        return challengeMapper.findPendingInvitationsByUserId(userId);
     }
 }

--- a/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
@@ -9,6 +9,7 @@ import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeParticipantDto;
 import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
 import com.pagoda.matchmeal.model.entity.Challenge;
+import com.pagoda.matchmeal.model.entity.ChallengeInvitation;
 import com.pagoda.matchmeal.model.entity.Diet;
 import com.pagoda.matchmeal.model.entity.DietDetail;
 import com.pagoda.matchmeal.model.enums.MealType;
@@ -54,6 +55,7 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .maxParticipants(dto.getMaxParticipants())
                 .isPublic(dto.isPublic())
                 .invitationCode(inviteCode)
+                .currentHeadCount(1)
                 .build();
 
         // 챌린지 저장
@@ -167,43 +169,44 @@ public class ChallengeServiceImpl implements ChallengeService {
      */
     @Override
     public void updateChallengeProgress(Long userId, Diet diet, List<DietDetail> details) {
-        // 유저가 참여 중인 챌린지 조회(DTO에 챌린지 마스터 정보 포함)
         List<ActiveChallengeDto> activeChallenges = challengeMapper.findActiveChallengesByUserId(userId);
         if (activeChallenges.isEmpty()) return;
 
-        LocalDate today = LocalDate.now();
+        LocalDate today = diet.getEatDate();
 
-        for (ActiveChallengeDto uc: activeChallenges) {
-            // 챌린지 기간 아니면 스킵
+        for (ActiveChallengeDto uc : activeChallenges) {
+
+            // 1. 기간 체크
             if (today.isBefore(uc.getStartDate()) || today.isAfter(uc.getEndDate())) {
                 continue;
             }
 
-            // 오늘 이미 성공했다면 스킵
+            // 2. 오늘 이미 성공했는지 체크 (1일 1회 성공 제한)
             if (uc.getLastSuccessDate() != null && uc.getLastSuccessDate().equals(today)) {
                 continue;
             }
 
             boolean isSuccess = false;
 
-            // 챌린지 타입별 로직
+            // 3. 타입별 성공 조건 체크
             switch (uc.getType()) {
-                // 습관형
+                // 기록형: 무엇이든 기록하면 성공 (특정 식사 타입 강제 제거)
                 case RECORD_FREQUENCY:
                     isSuccess = true;
                     break;
 
-                // 칼로리형
+                // 칼로리 제한형: 해당 식사가 목표 칼로리 이내인지
+                // (참고: 엄밀히 하려면 '하루 총 섭취 칼로리'를 계산해서 비교해야 하지만, 현재 로직은 '한 끼' 기준임)
                 case CALORIE_LIMIT:
-                    if (diet.getTotalCalories() < uc.getTargetValue()) {
+                    if (diet.getTotalCalories() <= uc.getTargetValue()) {
                         isSuccess = true;
                     }
                     break;
 
-                // 시간형
+                // 타임 어택: 지정 시간 이전에 식사했는지
                 case TIME_RANGE:
-                    if (diet.getMealType() == MealType.BREAKFAST &&
-                        diet.getEatTime().getHour() < uc.getTargetValue()) {
+                    // [수정] 아침식사 강제 조건 제거 -> 모든 식사에 대해 시간 체크
+                    if (diet.getEatTime().getHour() < uc.getTargetValue()) {
                         isSuccess = true;
                     }
                     break;
@@ -249,40 +252,33 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     /**
-     * 스트릭 계산 및 상태 업데이트
-     * @param uc
-     * @param today
+     * 카운트 및 스트릭 업데이트 (내부 메서드 통합 완료)
      */
     private void updateUserChallengeStatus(ActiveChallengeDto uc, LocalDate today) {
         int newCurrentCount = uc.getCurrentCount() + 1;
         int newCurrentStreak = 1;
 
-        // 연속 달성 로직
+        // 스트릭 계산 (마지막 성공일이 어제라면 연속 성공)
         if (uc.getLastSuccessDate() != null) {
-            // 마지막 성공일 어제? -> 연속 성공
             if (uc.getLastSuccessDate().equals(today.minusDays(1))) {
                 newCurrentStreak = uc.getCurrentStreak() + 1;
             }
-            
-            // 어제가 아니면 Streak은 1로 초기화
         }
 
-        // 최대 스트릭 갱신
         int newMaxStreak = Math.max(uc.getMaxStreak(), newCurrentStreak);
 
-        // DB 업데이트를 위한 파라미터 세팅
+        // DTO 값 갱신
         uc.setCurrentCount(newCurrentCount);
         uc.setCurrentStreak(newCurrentStreak);
         uc.setMaxStreak(newMaxStreak);
         uc.setLastSuccessDate(today);
 
-        // DB 업데이트 실행
+        // DB 업데이트
         challengeMapper.updateProgress(uc);
 
-        // 목표 달성 체크
+        // 목표 달성(졸업) 체크
         if (newCurrentCount >= uc.getGoalCount()) {
             challengeMapper.updateStatusToSuccess(uc.getUserChallengeId());
-
         }
     }
 
@@ -344,5 +340,82 @@ public class ChallengeServiceImpl implements ChallengeService {
         challengeMapper.deleteInvitationsByChallengeId(challengeId);
         challengeMapper.deleteUserChallengesByChallengeId(challengeId);
         challengeMapper.deleteChallengeById(challengeId);
+    }
+
+    /**
+     * 챌린지 떠나기
+     * @param userId
+     * @param challengeId
+     */
+    @Override
+    public void leaveChallenge(Long userId, Long challengeId) {
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            throw new CustomException(ErrorResponseCode.CHALLENGE_NOT_FOUND);
+        }
+
+        // 방장은 나가는것이 아닌 챌린지 삭제를 해야함
+        if (challenge.getOwnerId().equals(userId)) {
+            throw new CustomException(ErrorResponseCode.OWNER_CANNOT_LEAVE);
+        }
+
+        // 참여 여부 확인
+        if (!challengeMapper.existsByUserIdAndChallengeId(userId, challengeId)) {
+            throw new CustomException(ErrorResponseCode.NOT_JOINED_USER);
+        }
+
+        // 참여 기록 삭제
+        challengeMapper.deleteUserChallenge(userId, challengeId);
+
+        // 인원 수 감소
+        challengeMapper.decreaseHeadCount(challengeId);
+    }
+
+    /**
+     * 초대 응답 (승인/거절)
+     * @param userId
+     * @param invitationId
+     * @param isAccepted
+     */
+    @Override
+    public void respondInvitation(Long userId, Long invitationId, boolean isAccepted) {
+        // 초대장 조회
+        ChallengeInvitation invitation = challengeMapper.findInvitationById(invitationId);
+        if (invitation == null) {
+            throw new CustomException(ErrorResponseCode.INVITATION_NOT_FOUND);
+        }
+
+        // 본인 확인
+        if (!invitation.getInviteeId().equals(userId)) {
+            throw new CustomException(ErrorResponseCode.UNAUTHORIZED);
+        }
+
+        // 이미 처리된 초대장인지 확인
+        if (!"PENDING".equals(invitation.getStatus())) {
+            throw new CustomException(ErrorResponseCode.ALREADY_PROCESSED_INVITATION);
+        }
+
+        if (isAccepted) {
+            // 승인
+            Challenge challenge = challengeMapper.findById(invitation.getChallengeId());
+            if (challenge == null) {
+                // 삭제된 경우
+                challengeMapper.updateInvitationStatus(invitationId,"EXPIRED");
+                throw new CustomException(ErrorResponseCode.CHALLENGE_NOT_FOUND);
+            }
+
+            // 참여로직 호출
+            try {
+                joinChallengeLogic(userId, challenge);
+                // 상태 업데이트
+                challengeMapper.updateInvitationStatus(invitationId, "ACCEPTED");
+            } catch (CustomException e) {
+                // 실패 처리
+                throw e;
+            }
+        } else {
+            // 거절
+            challengeMapper.updateInvitationStatus(invitationId, "REJECTED");
+        }
     }
 }

--- a/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
@@ -3,16 +3,15 @@ package com.pagoda.matchmeal.service.impl;
 import com.pagoda.matchmeal.common.exception.CustomException;
 import com.pagoda.matchmeal.common.exception.ErrorResponseCode;
 import com.pagoda.matchmeal.mapper.ChallengeMapper;
+import com.pagoda.matchmeal.mapper.DietMapper;
 import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.request.ChallengeCreateRequestDto;
-import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
-import com.pagoda.matchmeal.model.dto.response.ChallengeInvitationResponseDto;
-import com.pagoda.matchmeal.model.dto.response.ChallengeParticipantDto;
-import com.pagoda.matchmeal.model.dto.response.ChallengeResponseDto;
+import com.pagoda.matchmeal.model.dto.response.*;
 import com.pagoda.matchmeal.model.entity.Challenge;
 import com.pagoda.matchmeal.model.entity.ChallengeInvitation;
 import com.pagoda.matchmeal.model.entity.Diet;
 import com.pagoda.matchmeal.model.entity.DietDetail;
+import com.pagoda.matchmeal.model.enums.ChallengeType;
 import com.pagoda.matchmeal.model.enums.MealType;
 import com.pagoda.matchmeal.service.ChallengeService;
 import com.pagoda.matchmeal.service.FollowService;
@@ -31,6 +30,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     private final ChallengeMapper challengeMapper;
     private final FollowService followService;
+    private final DietMapper dietMapper;
 
     /**
      * 챌린지 생성
@@ -175,46 +175,60 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         LocalDate today = diet.getEatDate();
 
-        for (ActiveChallengeDto uc : activeChallenges) {
+        // [1] 하루 누적 데이터 계산 (칼로리 챌린지용)
+        // 방금 기록한 식단이 포함된 오늘의 모든 식단을 가져옵니다.
+        List<DietResponseDto> todayDiets = dietMapper.findAllByDate(userId, today.toString());
+        double dailyTotalCalories = todayDiets.stream()
+                .mapToDouble(DietResponseDto::getTotalCalories)
+                .sum();
 
-            // 1. 기간 체크
+        for (ActiveChallengeDto uc : activeChallenges) {
+            // 기간 체크
             if (today.isBefore(uc.getStartDate()) || today.isAfter(uc.getEndDate())) {
                 continue;
             }
 
-            // 2. 오늘 이미 성공했는지 체크 (1일 1회 성공 제한)
-            if (uc.getLastSuccessDate() != null && uc.getLastSuccessDate().equals(today)) {
-                continue;
-            }
+            boolean isConditionMet = false;
 
-            boolean isSuccess = false;
-
-            // 3. 타입별 성공 조건 체크
+            // [2] 챌린지 타입별 조건 체크
             switch (uc.getType()) {
-                // 기록형: 무엇이든 기록하면 성공 (특정 식사 타입 강제 제거)
                 case RECORD_FREQUENCY:
-                    isSuccess = true;
+                    // 기록형: 기록만 하면 무조건 성공
+                    isConditionMet = true;
                     break;
 
-                // 칼로리 제한형: 해당 식사가 목표 칼로리 이내인지
-                // (참고: 엄밀히 하려면 '하루 총 섭취 칼로리'를 계산해서 비교해야 하지만, 현재 로직은 '한 끼' 기준임)
                 case CALORIE_LIMIT:
-                    if (diet.getTotalCalories() <= uc.getTargetValue()) {
-                        isSuccess = true;
+                    // 칼로리형: '하루 누적 칼로리'가 목표치 이하여야 함
+                    if (dailyTotalCalories <= uc.getTargetValue()) {
+                        isConditionMet = true;
                     }
                     break;
 
-                // 타임 어택: 지정 시간 이전에 식사했는지
                 case TIME_RANGE:
-                    // [수정] 아침식사 강제 조건 제거 -> 모든 식사에 대해 시간 체크
+                    // 타임어택: 방금 먹은 식사의 시간이 목표 시간 이전이어야 함
+                    // (주의: 하루에 여러 끼니 중 하나라도 시간 어기면 실패로 볼지, 성공한 끼니가 있으면 성공으로 볼지 정책 결정 필요)
+                    // 현재 정책: 이번 식사가 시간을 지켰으면 성공으로 간주
                     if (diet.getEatTime().getHour() < uc.getTargetValue()) {
-                        isSuccess = true;
+                        isConditionMet = true;
                     }
                     break;
             }
 
-            if (isSuccess) {
-                updateUserChallengeStatus(uc, today);
+            // [3] 상태 업데이트 로직 (성공 처리 OR 성공 취소)
+            boolean alreadySucceededToday = uc.getLastSuccessDate() != null && uc.getLastSuccessDate().equals(today);
+
+            if (isConditionMet) {
+                // 조건 만족 & 아직 오늘 성공 처리 안 됨 -> 성공 처리 (카운트 증가)
+                if (!alreadySucceededToday) {
+                    updateUserChallengeStatus(uc, today, true);
+                }
+                // 조건 만족 & 이미 성공 처리 됨 -> 유지 (아무것도 안 함)
+            } else {
+                // 조건 불만족 & 이미 오늘 성공 처리 됨 -> **성공 취소 (Rollback)**
+                // 예: 아침에 적게 먹어서 성공했는데, 저녁에 폭식해서 누적 칼로리 초과한 경우
+                if (alreadySucceededToday && uc.getType() == ChallengeType.CALORIE_LIMIT) {
+                    updateUserChallengeStatus(uc, today, false);
+                }
             }
         }
     }
@@ -253,33 +267,57 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     /**
-     * 카운트 및 스트릭 업데이트 (내부 메서드 통합 완료)
+     * 카운트/스트릭 증가 또는 감소(취소) 처리
+     * @param isSuccess true: 성공 처리, false: 성공 취소
      */
-    private void updateUserChallengeStatus(ActiveChallengeDto uc, LocalDate today) {
-        int newCurrentCount = uc.getCurrentCount() + 1;
-        int newCurrentStreak = 1;
+    private void updateUserChallengeStatus(ActiveChallengeDto uc, LocalDate today, boolean isSuccess) {
+        if (isSuccess) {
+            // [성공 처리]
+            int newCurrentCount = uc.getCurrentCount() + 1;
+            int newCurrentStreak = 1;
 
-        // 스트릭 계산 (마지막 성공일이 어제라면 연속 성공)
-        if (uc.getLastSuccessDate() != null) {
-            if (uc.getLastSuccessDate().equals(today.minusDays(1))) {
+            // 스트릭 계산
+            if (uc.getLastSuccessDate() != null && uc.getLastSuccessDate().equals(today.minusDays(1))) {
                 newCurrentStreak = uc.getCurrentStreak() + 1;
             }
-        }
 
-        int newMaxStreak = Math.max(uc.getMaxStreak(), newCurrentStreak);
+            int newMaxStreak = Math.max(uc.getMaxStreak(), newCurrentStreak);
 
-        // DTO 값 갱신
-        uc.setCurrentCount(newCurrentCount);
-        uc.setCurrentStreak(newCurrentStreak);
-        uc.setMaxStreak(newMaxStreak);
-        uc.setLastSuccessDate(today);
+            uc.setCurrentCount(newCurrentCount);
+            uc.setCurrentStreak(newCurrentStreak);
+            uc.setMaxStreak(newMaxStreak);
+            uc.setLastSuccessDate(today); // 오늘 날짜로 갱신
 
-        // DB 업데이트
-        challengeMapper.updateProgress(uc);
+            // DB 업데이트
+            challengeMapper.updateProgress(uc);
 
-        // 목표 달성(졸업) 체크
-        if (newCurrentCount >= uc.getGoalCount()) {
-            challengeMapper.updateStatusToSuccess(uc.getUserChallengeId());
+            // 목표 달성 체크
+            if (newCurrentCount >= uc.getGoalCount()) {
+                challengeMapper.updateStatusToSuccess(uc.getUserChallengeId());
+            }
+
+        } else {
+            // [성공 취소 - Rollback]
+            int newCurrentCount = Math.max(0, uc.getCurrentCount() - 1);
+            int newCurrentStreak = Math.max(0, uc.getCurrentStreak() - 1);
+
+            // 날짜 롤백 처리 (간소화: 스트릭이 0이 되면 날짜도 초기화, 아니면 유지)
+            LocalDate rollbackDate = (newCurrentStreak > 0) ? uc.getLastSuccessDate() : null;
+            // *참고: 더 정확히 하려면 '어제 날짜'를 계산해야 하지만, DTO에 없으므로 유지하거나 null 처리
+
+            uc.setCurrentCount(newCurrentCount);
+            uc.setCurrentStreak(newCurrentStreak);
+            uc.setLastSuccessDate(rollbackDate);
+
+            // 1. 수치 업데이트
+            challengeMapper.updateProgress(uc);
+
+            // 2. 상태 롤백 (SUCCESS -> PROGRESS)
+            // 목표 횟수를 달성해서 'SUCCESS' 상태였는데,
+            // 이번 취소로 인해 횟수가 부족해졌다면 다시 'PROGRESS'로 되돌림
+            if (newCurrentCount < uc.getGoalCount()) {
+                challengeMapper.updateStatusToProgress(uc.getUserChallengeId());
+            }
         }
     }
 

--- a/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
@@ -327,4 +327,22 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         challengeMapper.updateChallenge(challenge);
     }
+
+    @Override
+    public void deleteChallenge(Long userId, Long challengeId) {
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            throw new CustomException(ErrorResponseCode.CHALLENGE_NOT_FOUND);
+        }
+
+        // 권한 체크
+        if (!challenge.getOwnerId().equals(userId)) {
+            throw new CustomException(ErrorResponseCode.UNAUTHORIZED);
+        }
+
+        // 연관 데이터 삭제 (초대장 -> 참여중인 유저 -> 챌린지 순으로 삭제)
+        challengeMapper.deleteInvitationsByChallengeId(challengeId);
+        challengeMapper.deleteUserChallengesByChallengeId(challengeId);
+        challengeMapper.deleteChallengeById(challengeId);
+    }
 }

--- a/src/main/java/com/pagoda/matchmeal/service/impl/DietServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/DietServiceImpl.java
@@ -518,4 +518,13 @@ public class DietServiceImpl implements DietService {
         // 6. [기본] 밸런스 양호 (모든 오차가 10% 이내)
         return "탄단지 비율이 황금 밸런스입니다! 아주 훌륭해요! 🌿";
     }
+
+    /**
+     * [기간 조회] 특정 기간(Start~End)의 식단 리스트 반환
+     */
+    @Override
+    public List<DietResponseDto> getDietListByPeriod(Long userId, LocalDate startDate, LocalDate endDate) {
+        // LocalDate -> String 변환하여 Mapper 호출
+        return dietMapper.findAllByPeriod(userId, startDate.toString(), endDate.toString());
+    }
 }

--- a/src/main/java/com/pagoda/matchmeal/service/impl/DietServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/DietServiceImpl.java
@@ -11,6 +11,7 @@ import com.pagoda.matchmeal.model.dto.response.*;
 import com.pagoda.matchmeal.model.entity.Diet;
 import com.pagoda.matchmeal.model.entity.DietDetail;
 import com.pagoda.matchmeal.model.entity.Food;
+import com.pagoda.matchmeal.service.ChallengeService;
 import com.pagoda.matchmeal.service.DietService;
 import com.pagoda.matchmeal.service.FoodService;
 import com.pagoda.matchmeal.service.S3Service;
@@ -38,6 +39,7 @@ public class DietServiceImpl implements DietService {
     private final FoodMapper foodMapper;
     private final S3Service s3Service;
     private final FoodService foodService;
+    private final ChallengeService challengeService;
 
     /**
      * [식단 기록]
@@ -197,6 +199,9 @@ public class DietServiceImpl implements DietService {
         if (!finalDetails.isEmpty()) {
             dietMapper.insertDietDetails(finalDetails);
         }
+
+        // 챌린지 반영
+        challengeService.updateChallengeProgress(userId, diet, finalDetails);
 
         // 11. 생성된 ID 반환
         return diet.getDietId();

--- a/src/main/java/com/pagoda/matchmeal/service/impl/DietServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/DietServiceImpl.java
@@ -226,9 +226,10 @@ public class DietServiceImpl implements DietService {
         if (diet == null) {
             throw new CustomException(ErrorResponseCode.DIET_NOT_FOUND);
         }
-        if (!diet.getUserId().equals(userId)) {
-            throw new CustomException(ErrorResponseCode.UNAUTHORIZED);
-        }
+        // 챌린지 참여자간 공유 목적으로 임시 비활성화
+//        if (!diet.getUserId().equals(userId)) {
+//            throw new CustomException(ErrorResponseCode.UNAUTHORIZED);
+//        }
         return diet;
     }
 

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -216,8 +216,9 @@
             c.start_date       AS startDate,
             c.end_date         AS endDate,
             c.goal_count       AS goalCount,
-            c.max_participants AS maxParticipants, c.is_public        AS isPublic,
+            c.max_participants AS maxParticipants, c.is_public AS isPublic,
             c.invitation_code  AS invitationCode,
+            c.current_head_count AS currentHeadCount,
 
             (SELECT COUNT(*) FROM user_challenges uc_count WHERE uc_count.challenge_id = c.challenge_id) as currentHeadCount,
 
@@ -254,6 +255,30 @@
             goal_count = #{goalCount},
             max_participants = #{maxParticipants},
             is_public = #{isPublic}
+        WHERE challenge_id = #{challengeId}
+    </update>
+
+    <select id="findParticipantsByChallengeId" resultType="com.pagoda.matchmeal.model.dto.response.ChallengeParticipantDto">
+        SELECT
+            u.user_id      AS userId,
+            u.user_name    AS userName,
+            u.profile_image AS profileImage,
+
+            CASE
+                WHEN c.goal_count > 0 THEN
+                    TRUNCATE((uc.current_count * 100) / c.goal_count, 0)
+                ELSE 0
+                END AS progressPercent
+
+        FROM user_challenges uc
+                 JOIN users u ON uc.user_id = u.user_id
+                 JOIN challenges c ON uc.challenge_id = c.challenge_id  WHERE uc.challenge_id = #{challengeId}
+        ORDER BY uc.created_at ASC
+    </select>
+
+    <update id="increaseHeadCount">
+        UPDATE challenges
+        SET current_head_count = current_head_count + 1
         WHERE challenge_id = #{challengeId}
     </update>
 </mapper>

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -281,4 +281,19 @@
         SET current_head_count = current_head_count + 1
         WHERE challenge_id = #{challengeId}
     </update>
+
+    <delete id="deleteInvitationsByChallengeId">
+        DELETE FROM challenge_invitation
+        WHERE challenge_id = #{challengeId}
+    </delete>
+
+    <delete id="deleteUserChallengesByChallengeId">
+        DELETE FROM user_challenges
+        WHERE challenge_id = #{challengeId}
+    </delete>
+
+    <delete id="deleteChallengeById">
+        DELETE FROM challenges
+        WHERE challenge_id = #{challengeId}
+    </delete>
 </mapper>

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -280,7 +280,7 @@
     </update>
 
     <delete id="deleteInvitationsByChallengeId">
-        DELETE FROM challenge_invitation
+        DELETE FROM invitations
         WHERE challenge_id = #{challengeId}
     </delete>
 

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -117,23 +117,20 @@
 
     <select id="findActiveChallengesByUserId" resultType="com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto">
         SELECT
-            -- [유저 기록]
+            /* UserChallenge 정보 */
             uc.user_challenge_id AS userChallengeId,
             uc.current_count     AS currentCount,
             uc.current_streak    AS currentStreak,
             uc.max_streak        AS maxStreak,
             uc.last_success_date AS lastSuccessDate,
-
-            -- [챌린지 조건]
-            c.challenge_id       AS challengeId,
-            c.type               AS type,
+            uc.status            AS status,        /* Challenge 정보 */
+            c.challenge_id       AS challengeId,   c.title              AS title,         c.type               AS type,
             c.target_value       AS targetValue,
             c.start_date         AS startDate,
             c.end_date           AS endDate,
             c.goal_count         AS goalCount
-
         FROM user_challenges uc
-        JOIN challenges c ON uc.challenge_id = c.challenge_id
+                 JOIN challenges c ON uc.challenge_id = c.challenge_id
         WHERE uc.user_id = #{userId}
           AND uc.status = 'PROGRESS'
     </select>
@@ -296,4 +293,33 @@
         DELETE FROM challenges
         WHERE challenge_id = #{challengeId}
     </delete>
+
+    <delete id="deleteUserChallenge">
+        DELETE FROM user_challenges
+        WHERE user_id = #{userId} AND challenge_id = #{challengeId}
+    </delete>
+
+    <update id="decreaseHeadCount">
+        UPDATE challenges
+        SET current_head_count = current_head_count - 1
+        WHERE challenge_id = #{challengeId}
+    </update>
+
+    <select id="findInvitationById" resultType="com.pagoda.matchmeal.model.entity.ChallengeInvitation">
+        SELECT
+            invitation_id AS invitationId,
+            challenge_id  AS challengeId,
+            inviter_id    AS inviterId,
+            invitee_id    AS inviteeId,
+            status,
+            created_at    AS createdAt
+        FROM invitations
+        WHERE invitation_id = #{invitationId}
+    </select>
+
+    <update id="updateInvitationStatus">
+        UPDATE invitations
+        SET status = #{status}
+        WHERE invitation_id = #{invitationId}
+    </update>
 </mapper>

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -322,4 +322,32 @@
         SET status = #{status}
         WHERE invitation_id = #{invitationId}
     </update>
+
+    <select id="findPendingInvitationsByUserId" resultType="com.pagoda.matchmeal.model.dto.response.ChallengeInvitationResponseDto">
+        SELECT
+            i.invitation_id       AS invitationId,
+            i.created_at          AS sentAt,
+
+            /* 보낸 사람 정보 */
+            u.user_id             AS inviterId,
+            u.user_name           AS inviterName,
+            u.profile_image       AS inviterProfileImage,
+
+            /* 챌린지 정보 */
+            c.challenge_id        AS challengeId,
+            c.title               AS challengeTitle,
+            c.type                AS type,
+            c.target_value        AS targetValue,
+            c.goal_count          AS goalCount,
+            c.current_head_count  AS currentHeadCount,
+            c.max_participants    AS maxParticipants
+
+        FROM invitations i
+                 JOIN users u ON i.inviter_id = u.user_id
+                 JOIN challenges c ON i.challenge_id = c.challenge_id
+
+        WHERE i.invitee_id = #{userId}
+          AND i.status = 'PENDING'
+        ORDER BY i.created_at DESC
+    </select>
 </mapper>

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -183,6 +183,12 @@
         WHERE user_challenge_id = #{userChallengeId}
     </update>
 
+    <update id="updateStatusToProgress">
+        UPDATE user_challenges
+        SET status = 'PROGRESS'
+        WHERE user_challenge_id = #{userChallengeId}
+    </update>
+
     <update id="updateStatusToFail">
         UPDATE user_challenges
         SET status = 'FAIL',

--- a/src/main/resources/mappers/DietMapper.xml
+++ b/src/main/resources/mappers/DietMapper.xml
@@ -145,20 +145,26 @@
         ORDER BY eat_date ASC
     </select>
 
-<!--    <select id="findAllByPeriod" resultMap="DietResponseMap">-->
-<!--        SELECT d.*,-->
-<!--               dd.diet_detail_id, dd.food_id, dd.food_name, dd.quantity, dd.unit,-->
-<!--               dd.calories AS d_calories,-->
-<!--               dd.carbohydrate AS d_carbohydrate,-->
-<!--               dd.protein AS d_protein,-->
-<!--               dd.fat AS d_fat,-->
-<!--               dd.sugars AS d_sugars,-->
-<!--               dd.sodium AS d_sodium-->
-<!--        FROM diet_records d-->
-<!--                 LEFT JOIN diet_details dd ON d.diet_id = dd.diet_id-->
-<!--        WHERE d.user_id = #{userId}-->
-<!--          AND d.eat_date BETWEEN #{startDate} AND #{endDate} AND d.deleted_at IS NULL-->
-<!--        ORDER BY d.eat_date ASC, d.eat_time ASC-->
-<!--    </select>-->
+    <select id="findAllByPeriod" resultType="com.pagoda.matchmeal.model.dto.response.DietResponseDto">
+        SELECT
+            d.diet_id           AS dietId,
+            d.user_id           AS userId,
+            d.eat_date          AS eatDate,
+            d.eat_time          AS eatTime,
+            d.meal_type         AS mealType,
+            d.memo,
+            d.diet_img_url      AS dietImgUrl,
 
+            /* 영양소 정보 */
+            d.total_calories    AS totalCalories,
+            d.total_carbohydrate AS totalCarbohydrate,
+            d.total_protein     AS totalProtein,
+            d.total_fat         AS totalFat,
+            d.total_sugars      AS totalSugars,
+            d.total_sodium      AS totalSodium
+
+        FROM diet_records d  WHERE d.user_id = #{userId}
+                               AND d.eat_date BETWEEN #{startDate} AND #{endDate}
+        ORDER BY d.eat_date DESC, d.eat_time DESC
+    </select>
 </mapper>

--- a/src/main/resources/mappers/DietMapper.xml
+++ b/src/main/resources/mappers/DietMapper.xml
@@ -144,4 +144,21 @@
         GROUP BY eat_date
         ORDER BY eat_date ASC
     </select>
+
+<!--    <select id="findAllByPeriod" resultMap="DietResponseMap">-->
+<!--        SELECT d.*,-->
+<!--               dd.diet_detail_id, dd.food_id, dd.food_name, dd.quantity, dd.unit,-->
+<!--               dd.calories AS d_calories,-->
+<!--               dd.carbohydrate AS d_carbohydrate,-->
+<!--               dd.protein AS d_protein,-->
+<!--               dd.fat AS d_fat,-->
+<!--               dd.sugars AS d_sugars,-->
+<!--               dd.sodium AS d_sodium-->
+<!--        FROM diet_records d-->
+<!--                 LEFT JOIN diet_details dd ON d.diet_id = dd.diet_id-->
+<!--        WHERE d.user_id = #{userId}-->
+<!--          AND d.eat_date BETWEEN #{startDate} AND #{endDate} AND d.deleted_at IS NULL-->
+<!--        ORDER BY d.eat_date ASC, d.eat_time ASC-->
+<!--    </select>-->
+
 </mapper>

--- a/src/test/java/com/pagoda/matchmeal/service/ChallengeServiceTest.java
+++ b/src/test/java/com/pagoda/matchmeal/service/ChallengeServiceTest.java
@@ -7,6 +7,7 @@ import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.request.ChallengeCreateRequestDto;
 import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
 import com.pagoda.matchmeal.model.entity.Challenge;
+import com.pagoda.matchmeal.model.entity.ChallengeInvitation;
 import com.pagoda.matchmeal.model.entity.Diet;
 import com.pagoda.matchmeal.model.entity.Follow;
 import com.pagoda.matchmeal.model.enums.ChallengeType;
@@ -21,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -151,7 +153,10 @@ public class ChallengeServiceTest {
                 .build();
 
         // 400kcal 식단 (성공 조건)
-        Diet diet = Diet.builder().totalCalories(400).build();
+        Diet diet = Diet.builder()
+                .totalCalories(400)
+                .eatDate(today)
+                .build();
 
         given(challengeMapper.findActiveChallengesByUserId(userId))
                 .willReturn(List.of(activeDto));
@@ -186,7 +191,10 @@ public class ChallengeServiceTest {
                 .build();
 
         // 600kcal 식단 (실패 조건)
-        Diet diet = Diet.builder().totalCalories(600).build();
+        Diet diet = Diet.builder()
+                .totalCalories(600)
+                .eatDate(today)
+                .build();
 
         given(challengeMapper.findActiveChallengesByUserId(userId))
                 .willReturn(List.of(activeDto));
@@ -236,5 +244,208 @@ public class ChallengeServiceTest {
         // then
         // Mapper가 올바른 인자(userId, condition)로 호출되었는지 검증
         verify(challengeMapper).searchPublicChallenges(eq(userId), eq(condition));
+    }
+
+    /* =======================================================
+       [NEW] 1. 진척도 업데이트 테스트 (로직 변경 반영)
+       ======================================================= */
+
+    @Test
+    @DisplayName("진척도 업데이트 - 성공: 타임 어택 (모든 식사 시간 체크)")
+    void updateChallengeProgress_Success_TimeRange() {
+        // given
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+
+        ActiveChallengeDto activeDto = ActiveChallengeDto.builder()
+                .userChallengeId(100L)
+                .type(ChallengeType.TIME_RANGE)
+                .targetValue(20) // 20시(저녁 8시) 이전 식사 목표
+                .startDate(today.minusDays(1))
+                .endDate(today.plusDays(5))
+                .currentCount(0)
+                .build();
+
+        // 19:30에 먹은 저녁 식사 (성공 조건)
+        Diet diet = Diet.builder()
+                .eatDate(today)
+                .eatTime(LocalTime.of(19, 30))
+                .mealType(MealType.DINNER) // 아침이 아니어도 성공해야 함
+                .build();
+
+        given(challengeMapper.findActiveChallengesByUserId(userId))
+                .willReturn(List.of(activeDto));
+
+        // when
+        challengeService.updateChallengeProgress(userId, diet, Collections.emptyList());
+
+        // then
+        verify(challengeMapper).updateProgress(argThat(dto ->
+                dto.getCurrentCount() == 1 // 카운트 1 증가 확인
+        ));
+    }
+
+    @Test
+    @DisplayName("진척도 업데이트 - 성공: 기록형 (어떤 식사든 성공)")
+    void updateChallengeProgress_Success_RecordFrequency() {
+        // given
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+
+        ActiveChallengeDto activeDto = ActiveChallengeDto.builder()
+                .userChallengeId(200L)
+                .type(ChallengeType.RECORD_FREQUENCY)
+                .targetValue(0)
+                .startDate(today)
+                .endDate(today.plusDays(5))
+                .currentCount(5)
+                .goalCount(10)
+                .build();
+
+        // 점심 식사 기록
+        Diet diet = Diet.builder()
+                .eatDate(today)
+                .mealType(MealType.LUNCH)
+                .build();
+
+        given(challengeMapper.findActiveChallengesByUserId(userId))
+                .willReturn(List.of(activeDto));
+
+        // when
+        challengeService.updateChallengeProgress(userId, diet, Collections.emptyList());
+
+        // then
+        verify(challengeMapper).updateProgress(any());
+    }
+
+    /* =======================================================
+       [NEW] 2. 챌린지 나가기 테스트
+       ======================================================= */
+
+    @Test
+    @DisplayName("챌린지 나가기 - 성공")
+    void leaveChallenge_Success() {
+        // given
+        Long userId = 10L;
+        Long challengeId = 50L;
+        Long ownerId = 99L; // 방장은 다른 사람
+
+        Challenge challenge = Challenge.builder()
+                .challengeId(challengeId)
+                .ownerId(ownerId)
+                .build();
+
+        given(challengeMapper.findById(challengeId)).willReturn(challenge);
+        given(challengeMapper.existsByUserIdAndChallengeId(userId, challengeId)).willReturn(true);
+
+        // when
+        challengeService.leaveChallenge(userId, challengeId);
+
+        // then
+        verify(challengeMapper).deleteUserChallenge(userId, challengeId);
+        verify(challengeMapper).decreaseHeadCount(challengeId);
+    }
+
+    @Test
+    @DisplayName("챌린지 나가기 - 실패: 방장은 나갈 수 없음")
+    void leaveChallenge_Fail_Owner() {
+        // given
+        Long userId = 10L;
+        Long challengeId = 50L;
+
+        Challenge challenge = Challenge.builder()
+                .challengeId(challengeId)
+                .ownerId(userId) // 내가 방장
+                .build();
+
+        given(challengeMapper.findById(challengeId)).willReturn(challenge);
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.leaveChallenge(userId, challengeId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("code", ErrorResponseCode.OWNER_CANNOT_LEAVE);
+    }
+
+    /* =======================================================
+       [NEW] 3. 초대 응답 테스트
+       ======================================================= */
+
+    @Test
+    @DisplayName("초대 승인 - 성공")
+    void respondInvitation_Accept_Success() {
+        // given
+        Long userId = 10L;
+        Long invitationId = 1L;
+        Long challengeId = 100L;
+
+        ChallengeInvitation invitation = ChallengeInvitation.builder()
+                .invitationId(invitationId)
+                .inviteeId(userId)
+                .challengeId(challengeId)
+                .status("PENDING")
+                .build();
+
+        Challenge challenge = Challenge.builder()
+                .challengeId(challengeId)
+                .maxParticipants(10)
+                .build();
+
+        given(challengeMapper.findInvitationById(invitationId)).willReturn(invitation);
+        given(challengeMapper.findById(challengeId)).willReturn(challenge);
+        // 참여 가능 상태 가정 (중복X, 인원초과X)
+        given(challengeMapper.existsByUserIdAndChallengeId(userId, challengeId)).willReturn(false);
+        given(challengeMapper.countParticipants(challengeId)).willReturn(5);
+
+        // when
+        challengeService.respondInvitation(userId, invitationId, true);
+
+        // then
+        verify(challengeMapper).insertUserChallenge(userId, challengeId); // 참여
+        verify(challengeMapper).increaseHeadCount(challengeId); // 인원 증가
+        verify(challengeMapper).updateInvitationStatus(invitationId, "ACCEPTED"); // 상태 변경
+    }
+
+    @Test
+    @DisplayName("초대 거절 - 성공")
+    void respondInvitation_Reject_Success() {
+        // given
+        Long userId = 10L;
+        Long invitationId = 1L;
+
+        ChallengeInvitation invitation = ChallengeInvitation.builder()
+                .invitationId(invitationId)
+                .inviteeId(userId)
+                .status("PENDING")
+                .build();
+
+        given(challengeMapper.findInvitationById(invitationId)).willReturn(invitation);
+
+        // when
+        challengeService.respondInvitation(userId, invitationId, false); // 거절(false)
+
+        // then
+        verify(challengeMapper, never()).insertUserChallenge(anyLong(), anyLong()); // 참여 안 함
+        verify(challengeMapper).updateInvitationStatus(invitationId, "REJECTED"); // 거절 상태 변경
+    }
+
+    @Test
+    @DisplayName("초대 응답 - 실패: 본인 초대가 아님")
+    void respondInvitation_Fail_NotOwner() {
+        // given
+        Long userId = 10L;
+        Long otherUserId = 20L;
+        Long invitationId = 1L;
+
+        ChallengeInvitation invitation = ChallengeInvitation.builder()
+                .invitationId(invitationId)
+                .inviteeId(otherUserId) // 다른 사람이 받은 초대
+                .build();
+
+        given(challengeMapper.findInvitationById(invitationId)).willReturn(invitation);
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.respondInvitation(userId, invitationId, true))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("code", ErrorResponseCode.UNAUTHORIZED);
     }
 }

--- a/src/test/java/com/pagoda/matchmeal/service/ChallengeServiceTest.java
+++ b/src/test/java/com/pagoda/matchmeal/service/ChallengeServiceTest.java
@@ -3,9 +3,11 @@ package com.pagoda.matchmeal.service;
 import com.pagoda.matchmeal.common.exception.CustomException;
 import com.pagoda.matchmeal.common.exception.ErrorResponseCode;
 import com.pagoda.matchmeal.mapper.ChallengeMapper;
+import com.pagoda.matchmeal.mapper.DietMapper;
 import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.request.ChallengeCreateRequestDto;
 import com.pagoda.matchmeal.model.dto.response.ActiveChallengeDto;
+import com.pagoda.matchmeal.model.dto.response.DietResponseDto;
 import com.pagoda.matchmeal.model.entity.Challenge;
 import com.pagoda.matchmeal.model.entity.ChallengeInvitation;
 import com.pagoda.matchmeal.model.entity.Diet;
@@ -43,6 +45,9 @@ public class ChallengeServiceTest {
 
     @Mock
     private FollowService followService;
+
+    @Mock
+    private DietMapper dietMapper;
 
     @Test
     @DisplayName("챌린지 생성 성공")
@@ -158,6 +163,12 @@ public class ChallengeServiceTest {
                 .eatDate(today)
                 .build();
 
+        // findAllByDate가 400kcal짜리 식단 리스트를 반환한다고 가정
+        given(dietMapper.findAllByDate(eq(userId), anyString()))
+                .willReturn(List.of(
+                        DietResponseDto.builder().totalCalories(400).build()
+                ));
+
         given(challengeMapper.findActiveChallengesByUserId(userId))
                 .willReturn(List.of(activeDto));
 
@@ -195,6 +206,11 @@ public class ChallengeServiceTest {
                 .totalCalories(600)
                 .eatDate(today)
                 .build();
+
+        given(dietMapper.findAllByDate(eq(userId), anyString()))
+                .willReturn(List.of(
+                        DietResponseDto.builder().totalCalories(600).build()
+                ));
 
         given(challengeMapper.findActiveChallengesByUserId(userId))
                 .willReturn(List.of(activeDto));
@@ -273,6 +289,9 @@ public class ChallengeServiceTest {
                 .mealType(MealType.DINNER) // 아침이 아니어도 성공해야 함
                 .build();
 
+        given(dietMapper.findAllByDate(eq(userId), anyString()))
+                .willReturn(Collections.emptyList());
+
         given(challengeMapper.findActiveChallengesByUserId(userId))
                 .willReturn(List.of(activeDto));
 
@@ -307,6 +326,9 @@ public class ChallengeServiceTest {
                 .eatDate(today)
                 .mealType(MealType.LUNCH)
                 .build();
+
+        given(dietMapper.findAllByDate(eq(userId), anyString()))
+                .willReturn(Collections.emptyList());
 
         given(challengeMapper.findActiveChallengesByUserId(userId))
                 .willReturn(List.of(activeDto));


### PR DESCRIPTION
### 📋 개요 (Summary)

이번 PR은 챌린지 참여 유저의 라이프사이클(초대 수락/거절, 나가기) 기능을 완성하고, 식단 기록 시 챌린지 성공 여부를 판단하는 로직을 대폭 개선했습니다.
특히, **칼로리 제한 챌린지**에서 단일 식사가 아닌 **일일 누적 칼로리**를 기준으로 성공 여부를 재평가하도록 수정하여 데이터 정합성을 확보했습니다. 또한, 식단 조회 관련 테이블명 매핑 오류를 수정했습니다.

### 🛠 변경 사항 (Changes)

#### 1. ✨ 챌린지 멤버 관리 (Feature)

* **초대 목록 조회 (`GET /challenge/invitations`):** 대기 중인(`PENDING`) 초대장 목록을 조회하는 API 추가 (`ChallengeInvitationResponseDto`).
* **초대 응답 (`POST /challenge/invite/{id}/accept | reject`):** 초대 승인 시 챌린지 참여 처리 및 인원수(`currentHeadCount`) 증가, 거절 시 상태 변경 구현.
* **챌린지 나가기 (`POST /challenge/{id}/leave`):** 참여 중인 유저의 나가기 기능 구현 (방장 제외, 인원수 감소 처리).

#### 2. 🔄 식단-챌린지 진척도 연동 로직 개선 (Logic)

* **일일 누적 칼로리 체크:** 기존 단일 식단 기준에서 `DietMapper.findAllByDate`를 활용해 **당일 총 섭취 칼로리**를 계산하여 목표(`targetValue`)와 비교하도록 수정.
* **성공 상태 롤백(Revoke) 구현:** 이미 당일 성공 처리가 되었더라도, 추가 식단 기록으로 인해 목표(칼로리 등)를 초과하게 될 경우 **성공 취소(Count -1) 및 상태 원복(SUCCESS -> PROGRESS)** 로직 추가.
* **기간별 식단 조회 (`GET /diet/period`):** 챌린지 기간 동안의 식단 기록을 한 번에 조회할 수 있는 API 및 Mapper 추가 (타 유저 조회 지원).

#### 3. 🐛 버그 수정 (Fix)

* **테이블 매핑 오류 수정:** `DietMapper` XML에서 잘못된 테이블명(`diets`, `diet`)을 실제 DB 테이블명인 **`diet_records`**로 수정.
* **Controller 파라미터 매핑 수정:** `leaveChallenge`에서 `@PathVariable` 변수명 불일치로 인한 `MissingPathVariableException` 해결.
* **Frontend 문법 오류 수정:** `ChallengeDetailView.vue` 내 `@click` 핸들러에서 여러 구문 실행 시 세미콜론(`;`) 누락으로 인한 컴파일 에러 수정.

#### 4. ⚙️ 기타 (Refactor)

* **타인 식단 조회 권한 완화:** 챌린지 내 공유를 위해 `DietService.getDietDetail` 등의 조회 로직에서 본인 확인 제약을 `userId` 파라미터 기반 조회로 변경.

### 🔍 주요 로직 설명 (Key Logic)

**`ChallengeServiceImpl.updateChallengeProgress`**

```java
// 1. 당일 누적 칼로리 계산
double dailyTotal = dietMapper.findAllByDate(userId, today).stream()...sum();

// 2. 조건 초과 시 롤백 처리
if (alreadySucceeded && dailyTotal > targetValue) {
    uc.setCurrentCount(uc.getCurrentCount() - 1); // 카운트 감소
    challengeMapper.updateStatusToProgress(uc.getUserChallengeId()); // 상태 원복
}

```

### 🧪 테스트 계획 (Test Plan)

* [x] **Unit Test:** `ChallengeServiceTest` (초대 승인/거절, 나가기, 진척도 업데이트 성공/실패 케이스) 통과.
* [x] **Integration Test:**
1. 초대장 목록 조회 및 수락 후 참여자 리스트에 추가되는지 확인.
2. 식단 기록 후 `CALORIE_LIMIT` 챌린지 달성률 변화 확인.
3. (중요) 성공 상태에서 칼로리 초과 식단 추가 시 달성률이 감소하는지 확인.
4. 챌린지 기간 조회 API 호출 시 `diet_records` 테이블에서 정상적으로 데이터 반환 확인.



### ✅ 체크리스트 (Checklist)

* [x] 빌드 및 테스트가 정상적으로 수행됩니까?
* [x] DB 스키마(`diet_records`, `invitations`)와 매퍼 XML이 일치합니까?
* [x] 코딩 컨벤션을 준수했습니까?