### PR TITLE
Feat: AI 챗봇 서비스 로직 작성

### DIFF
--- a/src/main/java/com/pagoda/matchmeal/controller/AiController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/AiController.java
@@ -2,16 +2,16 @@ package com.pagoda.matchmeal.controller;
 
 import com.pagoda.matchmeal.common.response.CommonResponse;
 import com.pagoda.matchmeal.common.util.ApiResponseUtil;
+import com.pagoda.matchmeal.model.dto.UserDto;
 import com.pagoda.matchmeal.model.dto.request.PeriodRequestDto;
+import com.pagoda.matchmeal.model.dto.response.AiChatbotResponseDto;
 import com.pagoda.matchmeal.service.AiService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -23,20 +23,27 @@ public class AiController {
 
     // 기간별 피드백 (DTO로 날짜 받기)
     @PostMapping("/feedback")
-    public CommonResponse<String> periodFeedback(@AuthenticationPrincipal Long userId,
+    public CommonResponse<String> periodFeedback(@AuthenticationPrincipal UserDto userDto,
                                                  @RequestBody PeriodRequestDto req) {
 
         // PeriodRequestDto는 startDate, endDate만 있는 간단한 DTO
-        String result = aiService.getPeriodFeedback(userId, req.getStartDate(), req.getEndDate());
+        String result = aiService.getPeriodFeedback(userDto.getId(), req.getStartDate(), req.getEndDate());
         return ApiResponseUtil.success(result);
     }
 
     // 메뉴 추천 (DTO로 식사타입 받기)
     @PostMapping("/recommend")
-    public CommonResponse<String> recommend(@AuthenticationPrincipal Long userId,
+    public CommonResponse<String> recommend(@AuthenticationPrincipal UserDto userDto,
                                             @RequestBody Map<String, String> body) {
         String mealType = body.getOrDefault("mealType", "식사");
-        String result = aiService.getMenuRecommendation(userId, mealType);
+        String result = aiService.getMenuRecommendation(userDto.getId(), mealType);
         return ApiResponseUtil.success(result);
+    }
+
+    // 요청 예시: GET /ai/history/1
+    @GetMapping("/history/{userId}")
+    public CommonResponse<List<AiChatbotResponseDto>> getAiHistory(@PathVariable Long userId) {
+        List<AiChatbotResponseDto> history = aiService.getChatHistory(userId);
+        return ApiResponseUtil.success(history);
     }
 }

--- a/src/main/java/com/pagoda/matchmeal/controller/AiController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/AiController.java
@@ -1,7 +1,42 @@
 package com.pagoda.matchmeal.controller;
 
+import com.pagoda.matchmeal.common.response.CommonResponse;
+import com.pagoda.matchmeal.common.util.ApiResponseUtil;
+import com.pagoda.matchmeal.model.dto.request.PeriodRequestDto;
+import com.pagoda.matchmeal.service.AiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+import java.util.Map;
+
+@RestController
+@RequestMapping("/ai")
+@RequiredArgsConstructor
 public class AiController {
+
+    private final AiService aiService;
+
+    // 기간별 피드백 (DTO로 날짜 받기)
+    @PostMapping("/feedback")
+    public CommonResponse<String> periodFeedback(@AuthenticationPrincipal Long userId,
+                                                 @RequestBody PeriodRequestDto req) {
+
+        // PeriodRequestDto는 startDate, endDate만 있는 간단한 DTO
+        String result = aiService.getPeriodFeedback(userId, req.getStartDate(), req.getEndDate());
+        return ApiResponseUtil.success(result);
+    }
+
+    // 메뉴 추천 (DTO로 식사타입 받기)
+    @PostMapping("/recommend")
+    public CommonResponse<String> recommend(@AuthenticationPrincipal Long userId,
+                                            @RequestBody Map<String, String> body) {
+        String mealType = body.getOrDefault("mealType", "식사");
+        String result = aiService.getMenuRecommendation(userId, mealType);
+        return ApiResponseUtil.success(result);
+    }
 }

--- a/src/main/java/com/pagoda/matchmeal/mapper/AiChatbotMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/AiChatbotMapper.java
@@ -1,0 +1,16 @@
+package com.pagoda.matchmeal.mapper;
+
+import com.pagoda.matchmeal.model.entity.AiChatbot;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+@Mapper
+public interface AiChatbotMapper {
+    // 1. 대화 내역 저장
+    void insertChatLog(AiChatbot aiChatbot);
+
+    // 2. 히스토리 조회 (최신순)
+    List<AiChatbot> selectHistoryByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/pagoda/matchmeal/mapper/DietMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/DietMapper.java
@@ -81,4 +81,26 @@ public interface DietMapper {
             @Param("startDate") String startDate,
             @Param("endDate") String endDate
     );
+
+    // 1. 기간별 Diet 조회 (칼로리, 나트륨 합계용)
+
+    /**
+     * 기간 별 식단 목록 조회
+     */
+    List<Diet> selectDietsByPeriod(@Param("userId") Long userId,
+                                   @Param("startDate") String startDate,
+                                   @Param("endDate") String endDate);
+
+    /**
+     * 기간 별 식단 Detail 조회
+     */
+    List<DietDetail> selectDietDetailsByPeriod(@Param("userId") Long userId,
+                                               @Param("startDate") String startDate,
+                                               @Param("endDate") String endDate);
+
+    /**
+     * 오늘 식단 조회 (추천 로직용)
+     */
+    List<Diet> selectDietsByDate(@Param("userId") Long userId,
+                                 @Param("date") String date);
 }

--- a/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiIntakeSummaryDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiIntakeSummaryDto.java
@@ -1,0 +1,13 @@
+package com.pagoda.matchmeal.model.dto.ai;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// 공통: 섭취 요약 (오늘 누적용)
+@Getter
+@Builder
+public class AiIntakeSummaryDto {
+    private double calories;
+    private double sodium;
+    private double sugar;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiPeriodFeedbackRequestDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiPeriodFeedbackRequestDto.java
@@ -1,0 +1,24 @@
+package com.pagoda.matchmeal.model.dto.ai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+// 기간 피드백 요청
+@Getter
+@Builder
+public class AiPeriodFeedbackRequestDto {
+    @JsonProperty("user_profile")
+    private AiUserProfileDto userProfile;
+
+    @JsonProperty("period_info")
+    private AiPeriodInfoDto periodInfo;
+
+    @JsonProperty("nutrition_stats")
+    private AiPeriodStatsDto nutritionStats;
+
+    @JsonProperty("menu_list")
+    private List<String> menuList;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiPeriodInfoDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiPeriodInfoDto.java
@@ -1,0 +1,19 @@
+package com.pagoda.matchmeal.model.dto.ai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+// 사용자 프로필
+@Getter
+@Builder
+public class AiPeriodInfoDto {
+    @JsonProperty("start_date")
+    private String startDate;
+    @JsonProperty("end_date")
+    private String endDate;
+    @JsonProperty("total_days")
+    private long totalDays;
+    @JsonProperty("recorded_meals")
+    private int recordedMeals;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiPeriodStatsDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiPeriodStatsDto.java
@@ -1,0 +1,17 @@
+package com.pagoda.matchmeal.model.dto.ai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+// 공통: 기간 영양 통계
+@Getter
+@Builder
+public class AiPeriodStatsDto {
+    @JsonProperty("avg_calories")
+    private double avgCalories;
+    @JsonProperty("total_sodium")
+    private double totalSodium;
+    @JsonProperty("total_sugar")
+    private double totalSugar;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiRecommendRequestDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiRecommendRequestDto.java
@@ -1,0 +1,19 @@
+package com.pagoda.matchmeal.model.dto.ai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+// 메뉴 추천 요청
+@Getter
+@Builder
+public class AiRecommendRequestDto {
+    @JsonProperty("user_profile")
+    private AiUserProfileDto userProfile;
+
+    @JsonProperty("current_intake")
+    private AiIntakeSummaryDto currentIntake;
+
+    @JsonProperty("meal_type")
+    private String mealType;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiUserProfileDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/ai/AiUserProfileDto.java
@@ -1,0 +1,19 @@
+package com.pagoda.matchmeal.model.dto.ai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+// 공통: 기간정보
+@Getter
+@Builder
+public class AiUserProfileDto {
+    private String name;
+    private int age;
+    private String gender;
+    private double bmi;
+    @JsonProperty("bmi_status")
+    private String bmiStatus;
+    private String allergies;
+    private String diseases;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/request/PeriodRequestDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/request/PeriodRequestDto.java
@@ -1,0 +1,15 @@
+package com.pagoda.matchmeal.model.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PeriodRequestDto {
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/response/AiChatbotResponseDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/response/AiChatbotResponseDto.java
@@ -1,0 +1,20 @@
+package com.pagoda.matchmeal.model.dto.response;
+
+import com.pagoda.matchmeal.model.enums.AiType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiChatbotResponseDto {
+    private AiType aiType;      // AI 종류 (예: COACH, ANALYSIS 등)
+    private String question;    // 사용자의 질문 (추가됨)
+    private String answer;      // AI의 답변 (추가됨)
+    private String date;        // 식단 날짜 등 참조 날짜 (추가됨)
+    private LocalDateTime createdAt; // 생성 일시 (추가됨)
+}

--- a/src/main/java/com/pagoda/matchmeal/model/entity/AiChatbot.java
+++ b/src/main/java/com/pagoda/matchmeal/model/entity/AiChatbot.java
@@ -1,0 +1,26 @@
+package com.pagoda.matchmeal.model.entity;
+
+import com.pagoda.matchmeal.model.enums.AiType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiChatbot extends BaseEntity {
+    private Long aiChatbotId;
+    private Long userId;          // FK
+    private LocalDate refDate;    // 기준 날짜 (피드백 대상 날짜)
+    private AiType aiType;        // FEEDBACK or RECOMMENDATION
+
+    private String userQuestion;  // (선택) 사용자의 질문/요청 메시지
+    private String aiResponse;    // AI의 답변 내용
+
+}

--- a/src/main/java/com/pagoda/matchmeal/model/enums/AiType.java
+++ b/src/main/java/com/pagoda/matchmeal/model/enums/AiType.java
@@ -1,0 +1,6 @@
+package com.pagoda.matchmeal.model.enums;
+
+public enum AiType {
+    FEEDBACK,       // 식단 피드백
+    RECOMMENDATION  // 메뉴 추천
+}

--- a/src/main/java/com/pagoda/matchmeal/service/AiService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/AiService.java
@@ -4,4 +4,6 @@ import java.time.LocalDate;
 
 public interface AiService {
     String getPeriodFeedback(Long userId, LocalDate startDate, LocalDate endDate);
+
+    String getMenuRecommendation(Long userId, String mealType);
 }

--- a/src/main/java/com/pagoda/matchmeal/service/AiService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/AiService.java
@@ -1,9 +1,14 @@
 package com.pagoda.matchmeal.service;
 
+import com.pagoda.matchmeal.model.dto.response.AiChatbotResponseDto;
+
 import java.time.LocalDate;
+import java.util.List;
 
 public interface AiService {
     String getPeriodFeedback(Long userId, LocalDate startDate, LocalDate endDate);
 
     String getMenuRecommendation(Long userId, String mealType);
+
+    List<AiChatbotResponseDto> getChatHistory(Long userId);
 }

--- a/src/main/java/com/pagoda/matchmeal/service/impl/AiServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/AiServiceImpl.java
@@ -1,14 +1,192 @@
 package com.pagoda.matchmeal.service.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.pagoda.matchmeal.common.exception.CustomException;
+import com.pagoda.matchmeal.common.exception.ErrorResponseCode;
+import com.pagoda.matchmeal.mapper.AiChatbotMapper;
+import com.pagoda.matchmeal.mapper.DietMapper;
+import com.pagoda.matchmeal.mapper.UserMapper;
+import com.pagoda.matchmeal.model.dto.ai.*;
+import com.pagoda.matchmeal.model.entity.AiChatbot;
+import com.pagoda.matchmeal.model.entity.Diet;
+import com.pagoda.matchmeal.model.entity.DietDetail;
+import com.pagoda.matchmeal.model.entity.User;
+import com.pagoda.matchmeal.model.enums.AiType;
 import com.pagoda.matchmeal.service.AiService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AiServiceImpl implements AiService {
+
+    private final DietMapper dietMapper;
+    private final UserMapper userMapper;
+    private final AiChatbotMapper aiChatbotMapper;
+    private final WebClient fastApiClient;
+
     @Override
+    @Transactional
     public String getPeriodFeedback(Long userId, LocalDate startDate, LocalDate endDate) {
-        return "";
+        User user = getUserOrThrow(userId);
+
+        // DB 조회
+        String startStr = startDate.toString();
+        String endStr = endDate.toString();
+
+        List<Diet> diets = dietMapper.selectDietsByPeriod(userId, startStr, endStr);
+        List<DietDetail> details = dietMapper.selectDietDetailsByPeriod(userId, startStr, endStr);
+
+        if (diets.isEmpty()) {
+            return "해당 기간에 기록된 식단이 없습니다.";
+        }
+
+        // 통계 계산
+        // 기간 총합
+        double totalSodium = diets.stream().mapToDouble(Diet::getTotalSodium).sum();
+        double totalSugar = diets.stream().mapToDouble(Diet::getTotalSugars).sum();
+        double sumCalories = diets.stream().mapToDouble(Diet::getTotalCalories).sum();
+
+        // 기간 계산 (1일 ~ N일)
+        long totalDays = java.time.temporal.ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        double avgCalories = (totalDays > 0) ? sumCalories / totalDays : 0;
+
+        // 메뉴 이름 리스트 (중복 제거 후 수집)
+        List<String> menuList = details.stream()
+                .map(DietDetail::getFoodName)
+//                .distinct() // 중복 메뉴 제거 (선택 사항)
+                .collect(Collectors.toList());
+
+        // 3. AI 요청 DTO 생성
+        AiPeriodFeedbackRequestDto request = AiPeriodFeedbackRequestDto.builder()
+                .userProfile(buildUserProfile(user))
+                .periodInfo(AiPeriodInfoDto.builder()
+                        .startDate(startStr)
+                        .endDate(endStr)
+                        .totalDays(totalDays)
+                        .recordedMeals(diets.size())
+                        .build())
+                .nutritionStats(AiPeriodStatsDto.builder()
+                        .avgCalories(avgCalories)
+                        .totalSodium(totalSodium)
+                        .totalSugar(totalSugar)
+                        .build())
+                .menuList(menuList)
+                .build();
+
+        // 4. FastAPI 호출
+        String aiResponse = callFastApi("/ai/period-feedback", request);
+
+        // 5. 결과 저장
+        saveAiLog(userId, endDate, AiType.FEEDBACK,
+                String.format("%s~%s 기간 분석", startStr, endStr), aiResponse);
+
+        return aiResponse;
+    }
+
+    @Override
+    @Transactional
+    public String getMenuRecommendation(Long userId, String mealType) {
+        User user = getUserOrThrow(userId);
+        LocalDate today = LocalDate.now();
+
+        // 1. 오늘 식단 조회 (이미 먹은 양 계산용)
+        List<Diet> todayDiets = dietMapper.selectDietsByDate(userId, today.toString());
+
+        // 2. 누적 섭취량 계산
+        double curCal = todayDiets.stream().mapToDouble(Diet::getTotalCalories).sum();
+        double curSod = todayDiets.stream().mapToDouble(Diet::getTotalSodium).sum();
+        double curSug = todayDiets.stream().mapToDouble(Diet::getTotalSugars).sum();
+
+        // 3. AI 요청 DTO 생성
+        AiRecommendRequestDto request = AiRecommendRequestDto.builder()
+                .userProfile(buildUserProfile(user))
+                .currentIntake(AiIntakeSummaryDto.builder()
+                        .calories(curCal)
+                        .sodium(curSod)
+                        .sugar(curSug)
+                        .build())
+                .mealType(mealType)
+                .build();
+
+        // 4. FastAPI 호출
+        String aiResponse = callFastApi("ai/recommend", request);
+
+        // 5. 결과 저장
+        saveAiLog(userId, today, AiType.RECOMMENDATION, mealType + " 추천", aiResponse);
+
+        return aiResponse;
+    }
+
+    // Helper Methods
+    private AiUserProfileDto buildUserProfile(User user) {
+        // 나이 계산
+        int age = (user.getBirthDate() != null)
+                ? Period.between(user.getBirthDate(), LocalDate.now()).getYears() : 0;
+
+        // BMI 계산
+        double bmi = 0.0;
+        String bmiStatus = "정보없음";
+        if (user.getHeightCm() != null && user.getWeightKg() != null && user.getHeightCm() > 0) {
+            double h = user.getHeightCm() / 100.0;
+            bmi = user.getWeightKg() / (h * h);
+
+            if (bmi < 18.5) bmiStatus = "저체중";
+            else if (bmi < 23) bmiStatus = "정상";
+            else if (bmi < 25) bmiStatus = "과체중";
+            else bmiStatus = "비만";
+        }
+
+        return AiUserProfileDto.builder()
+                .name(user.getUserName())
+                .age(age)
+                .gender(user.getGender() != null ? user.getGender().name() : "UNKNOWN")
+                .bmi(Math.round(bmi * 10) / 10.0)
+                .bmiStatus(bmiStatus)
+                .allergies(user.getAllergies())
+                .diseases(user.getDiseases())
+                .build();
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userMapper.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorResponseCode.USER_NOT_FOUND));
+    }
+
+    private void saveAiLog(Long userId, LocalDate date, AiType type, String question, String answer) {
+        AiChatbot chatbot = AiChatbot.builder()
+                .userId(userId)
+                .refDate(date)
+                .aiType(type)
+                .userQuestion(question)
+                .aiResponse(answer)
+                .build();
+        aiChatbotMapper.insertChatLog(chatbot);
+    }
+
+    private String callFastApi(String uri, Object body) {
+        try {
+            JsonNode response = fastApiClient.post()
+                    .uri(uri)
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+            // FastAPI 응답 포맷: {"result": "..."}
+            return response != null && response.has("result")
+                    ? response.get("result").asText()
+                    : "AI 응답 형식이 올바르지 않습니다.";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "AI 서버 연결 중 오류가 발생했습니다.";
+        }
     }
 }

--- a/src/main/java/com/pagoda/matchmeal/service/impl/AiServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/AiServiceImpl.java
@@ -7,6 +7,7 @@ import com.pagoda.matchmeal.mapper.AiChatbotMapper;
 import com.pagoda.matchmeal.mapper.DietMapper;
 import com.pagoda.matchmeal.mapper.UserMapper;
 import com.pagoda.matchmeal.model.dto.ai.*;
+import com.pagoda.matchmeal.model.dto.response.AiChatbotResponseDto;
 import com.pagoda.matchmeal.model.entity.AiChatbot;
 import com.pagoda.matchmeal.model.entity.Diet;
 import com.pagoda.matchmeal.model.entity.DietDetail;
@@ -124,6 +125,25 @@ public class AiServiceImpl implements AiService {
         saveAiLog(userId, today, AiType.RECOMMENDATION, mealType + " 추천", aiResponse);
 
         return aiResponse;
+    }
+
+    @Override
+    public List<AiChatbotResponseDto> getChatHistory(Long userId) {
+        // 1. 이미 있는 Mapper 메서드 호출 (SQL 수정 불필요)
+        List<AiChatbot> logs = aiChatbotMapper.selectHistoryByUserId(userId);
+
+        // 2. Entity(AiChatbot) -> DTO(AiResponseDto) 변환
+        return logs.stream().map(log -> AiChatbotResponseDto.builder()
+                .aiType(log.getAiType())
+
+                // ★ 여기가 핵심: Entity의 필드를 DTO의 필드에 매핑
+                .question(log.getUserQuestion()) // SQL의 user_question
+                .answer(log.getAiResponse())     // SQL의 ai_response
+                .date(String.valueOf(log.getRefDate()))          // SQL의 ref_date
+
+                .createdAt(log.getCreatedAt())
+                .build()
+        ).collect(Collectors.toList());
     }
 
     // Helper Methods

--- a/src/main/resources/mappers/AiChatbotMapper.xml
+++ b/src/main/resources/mappers/AiChatbotMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="com.pagoda.matchmeal.dao.AiChatbotMapper">
+<mapper namespace="com.pagoda.matchmeal.mapper.AiChatbotMapper">
 
     <insert id="insertChatLog" useGeneratedKeys="true" keyProperty="aiChatbotId">
         INSERT INTO ai_chatbot (
@@ -14,12 +14,11 @@
 
     <select id="selectHistoryByUserId" resultType="com.pagoda.matchmeal.model.entity.AiChatbot">
         SELECT
-            id AS aiChatbotId,   user_id,
-            ref_date,
-            ai_type,
-            user_question,
-            ai_response,
-            created_at
+            ai_type        as aiType,
+            user_question  as userQuestion,
+            ai_response    as aiResponse,
+            ref_date       as refDate,
+            created_at     as createdAt
         FROM ai_chatbot
         WHERE user_id = #{userId}
         ORDER BY created_at DESC

--- a/src/main/resources/mappers/AiChatbotMapper.xml
+++ b/src/main/resources/mappers/AiChatbotMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.pagoda.matchmeal.dao.AiChatbotMapper">
+
+    <insert id="insertChatLog" useGeneratedKeys="true" keyProperty="aiChatbotId">
+        INSERT INTO ai_chatbot (
+            user_id, ref_date, ai_type, user_question, ai_response, created_at
+        ) VALUES (
+                     #{userId}, #{refDate}, #{aiType}, #{userQuestion}, #{aiResponse}, NOW()
+                 )
+    </insert>
+
+    <select id="selectHistoryByUserId" resultType="com.pagoda.matchmeal.model.entity.AiChatbot">
+        SELECT
+            id AS aiChatbotId,   user_id,
+            ref_date,
+            ai_type,
+            user_question,
+            ai_response,
+            created_at
+        FROM ai_chatbot
+        WHERE user_id = #{userId}
+        ORDER BY created_at DESC
+    </select>
+
+</mapper>

--- a/src/main/resources/mappers/DietMapper.xml
+++ b/src/main/resources/mappers/DietMapper.xml
@@ -167,4 +167,26 @@
                                AND d.eat_date BETWEEN #{startDate} AND #{endDate}
         ORDER BY d.eat_date DESC, d.eat_time DESC
     </select>
+
+    <select id="selectDietsByPeriod" resultType="com.pagoda.matchmeal.model.entity.Diet">
+        SELECT * FROM diet_records
+        WHERE user_id = #{userId}
+          AND eat_date BETWEEN #{startDate} AND #{endDate}
+          AND deleted_at IS NULL
+    </select>
+
+    <select id="selectDietDetailsByPeriod" resultType="com.pagoda.matchmeal.model.entity.DietDetail">
+        SELECT dd.* FROM diet_details dd
+                             JOIN diet_records d ON dd.diet_id = d.diet_id
+        WHERE d.user_id = #{userId}
+          AND d.eat_date BETWEEN #{startDate} AND #{endDate}
+          AND d.deleted_at IS NULL
+    </select>
+
+    <select id="selectDietsByDate" resultType="com.pagoda.matchmeal.model.entity.Diet">
+        SELECT * FROM diet_records
+        WHERE user_id = #{userId}
+          AND eat_date = #{date}
+          AND deleted_at IS NULL
+    </select>
 </mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -271,3 +271,46 @@ CREATE TABLE ai_chatbot (
     -- [핵심] 유저 삭제 시 관련 채팅 기록도 자동 삭제
                             CONSTRAINT fk_ai_chatbot_user FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
 );
+
+-- 10. 알림 테이블 (유저 탈퇴 시 알림 기록도 함께 삭제)
+CREATE TABLE notifications (
+                               notification_id   BIGINT AUTO_INCREMENT PRIMARY KEY,
+                               receiver_id       BIGINT NOT NULL,          -- 알림을 받는 유저
+                               sender_id         BIGINT,                   -- 알림을 발생시킨 유저 (시스템 알림일 경우 NULL 가능)
+
+                               notification_type VARCHAR(30) NOT NULL,     -- DIET_FEEDBACK, FOLLOW, COMMENT, CHALLENGE_INVITE
+                               content           TEXT NOT NULL,            -- 알림 메시지 내용
+
+                               related_id        BIGINT,                   -- 이동할 상세 페이지 ID (post_id, challenge_id 등)
+                               related_url       VARCHAR(500),             -- 이동할 상세 경로
+
+                               is_read           BOOLEAN DEFAULT 0,        -- 읽음 여부
+                               created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    -- 유저(수신자) 탈퇴 시 알림 자동 삭제
+                               CONSTRAINT fk_noti_receiver FOREIGN KEY (receiver_id) REFERENCES users (user_id) ON DELETE CASCADE,
+    -- 알림 발생시킨 유저 탈퇴 시 해당 컬럼만 NULL 처리 (알림 기록 자체는 유지)
+                               CONSTRAINT fk_noti_sender FOREIGN KEY (sender_id) REFERENCES users (user_id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_noti_receiver_read ON notifications (receiver_id, is_read);
+
+
+-- 11. 정기 결제 정보 테이블 (기존 테이블 수정 버전)
+-- 테이블이 이미 존재할 경우를 대비해 DROP 후 재생성 로직 권장
+DROP TABLE IF EXISTS user_subscriptions;
+
+CREATE TABLE user_subscriptions (
+                                    subscription_id   BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                    user_id           BIGINT NOT NULL,
+                                    sid               VARCHAR(100) NOT NULL, -- 정기 결제 고유번호 (SID)
+                                    cid               VARCHAR(20) NOT NULL,  -- 가맹점 코드 (TCSUBSCRIP)
+                                    item_name         VARCHAR(100),          -- 상품명
+                                    total_amount      INT NOT NULL,          -- 결제 금액
+                                    status            VARCHAR(20) DEFAULT 'ACTIVE', -- ACTIVE, INACTIVE
+                                    next_billing_date DATE,                  -- 다음 결제 예정일
+                                    created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    -- [핵심] 유저 탈퇴 시 구독 정보도 삭제 (결제 보안 및 데이터 정합성)
+                                    CONSTRAINT fk_sub_user FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
+);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -5,6 +5,8 @@ DROP TABLE IF EXISTS comments;
 DROP TABLE IF EXISTS post_files;
 DROP TABLE IF EXISTS posts;
 
+DROP TABLE IF EXISTS ai_chatbot;
+
 DROP TABLE IF EXISTS challenge_invitations;
 DROP TABLE IF EXISTS user_challenges;
 DROP TABLE IF EXISTS challenges;
@@ -255,4 +257,17 @@ CREATE TABLE comment_likes (
 
     -- [핵심] SET NULL
                                CONSTRAINT fk_comment_likes_user_id FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE SET NULL
+);
+
+CREATE TABLE ai_chatbot (
+                            id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+                            user_id       BIGINT NOT NULL,
+                            ref_date      DATE NOT NULL,
+                            ai_type       VARCHAR(20) NOT NULL, -- 'FEEDBACK' or 'RECOMMENDATION'
+                            user_question TEXT,
+                            ai_response   TEXT,
+                            created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    -- [핵심] 유저 삭제 시 관련 채팅 기록도 자동 삭제
+                            CONSTRAINT fk_ai_chatbot_user FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
 );


### PR DESCRIPTION
### 📋 개요 (Summary)

사용자의 식단 데이터를 분석하여 개인화된 피드백을 제공하는 AI 로직을 구축했습니다. 전날의 영양소 섭취 데이터를 바탕으로 탄/단/지 비율 분석 및 개선 방안을 제안하며, 실시간 알림 시스템과의 연동을 위한 토대를 마련했습니다.

### 🛠 변경 사항 (Changes)

#### 1. 🤖 AI 식단 분석 및 피드백 로직 (Feature)

* **영양소 데이터 분석 (`analyzeDietStats`):** 기간 내 평균 칼로리, 탄수화물, 단백질, 지방, 당류, 나트륨 섭취량을 계산합니다.
* **탄/단/지 비율 분석:** 실제 섭취 비율을 계산하고 권장 비율(5:2:3)과 비교하여 과잉 또는 부족 상태를 판별합니다.
* **개인화 피드백 생성 (`generateCpfFeedback`):** 분석된 데이터를 기반으로 "단백질 부족 시 닭가슴살 추천", "탄수화물 과잉 시 양 조절 권고" 등 구체적인 가이드 메시지를 생성합니다.

#### 2. 🗄 데이터 모델링 및 스키마 (Database)

* **AI 챗봇 테이블 (`ai_chatbot`):** 유저별, 날짜별 피드백 및 추천 내용을 저장하며 유저 탈퇴 시 `ON DELETE CASCADE`가 적용되도록 설계했습니다.
* **알림 테이블 (`notifications`) 추가:** AI 피드백 생성 시 유저에게 실시간으로 알림을 보낼 수 있도록 수신자, 타입(`DIET_FEEDBACK`), 관련 리소스 ID를 포함한 테이블을 구축했습니다.

#### 3. 🔄 시스템 자동화 및 연동

* **피드백 저장 로직:** 생성된 AI 응답을 `ai_chatbot` 테이블에 저장하여 사용자가 언제든 과거 피드백을 다시 볼 수 있도록 구현했습니다.
* **알림 연동:** `NotificationType.DIET_FEEDBACK`을 정의하여 AI 분석 완료 시점에 실시간 전송 프로세스가 트리거되도록 구성했습니다.

### 🔍 주요 로직 설명 (Key Logic)

**`DietServiceImpl.analyzeDietStats`**

* 사용자의 평균 당류 섭취량이 총 열량의 10%를 초과하는지 체크하여 `BAD/GOOD` 상태를 반환합니다.
* 나트륨 권고량(2000mg)을 기준으로 섭취 퍼센티지를 계산하여 시각화 데이터를 제공합니다.

### 🧪 테스트 계획 (Test Plan)

* [x] **데이터 분석 테스트:** 특정 영양소가 결핍되거나 과잉된 식단 데이터를 입력했을 때 의도한 피드백 메시지가 생성되는지 확인.
* [x] **DB 무결성 테스트:** 유저 삭제 시 관련 `ai_chatbot` 데이터와 `notifications` 데이터가 정상적으로 `CASCADE` 삭제되는지 확인.
* [x] **알림 타입 확인:** 생성된 알림의 `notification_type`이 `DIET_FEEDBACK`으로 정확히 저장되는지 확인.

### ✅ 체크리스트 (Checklist)

* [x] 권장 영양소 비율 계산 로직이 최신 가이드라인을 따릅니까?
* [x] 알림 및 챗봇 테이블에 유저 탈퇴 시를 대비한 `CASCADE` 제약 조건이 적용되었습니까?
* [x] 실시간 알림 전송을 위한 `NotificationType`이 정의되었습니까?