### PR TITLE
Feat: 카카오페이 정기결제 연동 및 구독 수명주기(Lifecycle) 관리 로직 구현

### DIFF
--- a/src/main/java/com/pagoda/matchmeal/common/config/SecurityConfig.java
+++ b/src/main/java/com/pagoda/matchmeal/common/config/SecurityConfig.java
@@ -67,7 +67,9 @@ public class SecurityConfig {
                 // URL 권한 설정
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/user/reactivate").hasRole("WITHDRAWN") // 임시 토큰 가진 사람만 접근 가능
-                        .requestMatchers("/user/**").hasRole("USER") // 일반 유저
+                        .requestMatchers("/user/**").hasAnyRole("USER", "SUBSCRIBER") // 일반 유저 및 구독자
+                        .requestMatchers("/ai/**").hasRole("SUBSCRIBER") // ★ AI 기능은 구독자만 접근 가능
+                        .requestMatchers("/payment/**").hasAnyRole("USER", "SUBSCRIBER") // 결제 관련 접근 허용
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/css/**", "/images/**", "/js/**", "/login/**", "/favicon.ico", "/error").permitAll()
                         .requestMatchers(

--- a/src/main/java/com/pagoda/matchmeal/common/exception/ErrorResponseCode.java
+++ b/src/main/java/com/pagoda/matchmeal/common/exception/ErrorResponseCode.java
@@ -21,6 +21,10 @@ public enum ErrorResponseCode {
     ALREADY_USER_DELETE(HttpStatus.BAD_REQUEST, "이미 탈퇴처리된 회원입니다."),
     USER_WITHDRAWN_WAITING(HttpStatus.BAD_REQUEST, "탈퇴한 회원입니다. 복구 또는 재가입을 선택해주세요."),
 
+    //---------------------------- 구독 에러코드----------------------------
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "구독을 찾을 수 없습니다."),
+    PAYMENT_TID_NOT_FOUND(HttpStatus.NOT_FOUND, "TID를 찾을 수 없습니다."),
+
     //----------------------------식단 에러코드----------------------------
     DIET_NOT_FOUND(HttpStatus.NOT_FOUND, "식단 데이터를 찾을 수 없습니다."),
 

--- a/src/main/java/com/pagoda/matchmeal/common/exception/ErrorResponseCode.java
+++ b/src/main/java/com/pagoda/matchmeal/common/exception/ErrorResponseCode.java
@@ -11,6 +11,7 @@ public enum ErrorResponseCode {
     //----------------------------공통코드----------------------------
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
 //    INVALID_FILE(HttpStatus.)
 
     //----------------------------음식DB 에러코드----------------------------

--- a/src/main/java/com/pagoda/matchmeal/controller/KakaoPayController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/KakaoPayController.java
@@ -29,10 +29,22 @@ public class KakaoPayController {
         return ApiResponseUtil.success("구독이 완료되었습니다!");
     }
 
+    @GetMapping("/my-subscription")
+    public CommonResponse<com.pagoda.matchmeal.model.dto.response.SubscriptionResponseDto> getMySubscription(@AuthenticationPrincipal UserDto userDto) {
+        return ApiResponseUtil.success(kakaoPayService.getMySubscription(userDto.getId()));
+    }
+
     // 3. 구독 해지 요청
     @PostMapping("/cancel")
     public CommonResponse<String> cancel(@AuthenticationPrincipal UserDto userDto) {
         kakaoPayService.cancelSubscription(userDto.getId());
         return ApiResponseUtil.success("정기 구독이 성공적으로 해지되었습니다.");
+    }
+
+    // 4. 구독 재활성화 요청
+    @PostMapping("/reactivate")
+    public CommonResponse<String> reactivate(@AuthenticationPrincipal UserDto userDto) {
+        kakaoPayService.reactivateSubscription(userDto.getId());
+        return ApiResponseUtil.success("구독이 다시 활성화되었습니다. 예정된 날짜에 결제됩니다.");
     }
 }

--- a/src/main/java/com/pagoda/matchmeal/controller/KakaoPayController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/KakaoPayController.java
@@ -1,0 +1,38 @@
+package com.pagoda.matchmeal.controller;
+
+import com.pagoda.matchmeal.common.response.CommonResponse;
+import com.pagoda.matchmeal.common.util.ApiResponseUtil;
+import com.pagoda.matchmeal.model.dto.UserDto;
+import com.pagoda.matchmeal.model.dto.response.KakaoReadyResponse;
+import com.pagoda.matchmeal.service.KakaoPayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/payment")
+@RequiredArgsConstructor
+public class KakaoPayController {
+    private final KakaoPayService kakaoPayService;
+
+    // 1. 결제 준비 요청 (Ready)
+    @PostMapping("/ready")
+    public KakaoReadyResponse ready(@AuthenticationPrincipal UserDto userDto) {
+        return kakaoPayService.ready(userDto.getId());
+    }
+
+    @GetMapping("/success")
+    public CommonResponse<String> success(@RequestParam("pg_token") String pgToken,
+                                          @RequestParam("userId") Long userId) {
+        // pgToken을 서비스로 넘겨서 카카오 승인 API를 호출하고 SID를 발급받음
+        kakaoPayService.approveFirstPayment(pgToken, userId);
+        return ApiResponseUtil.success("구독이 완료되었습니다!");
+    }
+
+    // 3. 구독 해지 요청
+    @PostMapping("/cancel")
+    public CommonResponse<String> cancel(@AuthenticationPrincipal UserDto userDto) {
+        kakaoPayService.cancelSubscription(userDto.getId());
+        return ApiResponseUtil.success("정기 구독이 성공적으로 해지되었습니다.");
+    }
+}

--- a/src/main/java/com/pagoda/matchmeal/mapper/SubscriptionMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/SubscriptionMapper.java
@@ -1,0 +1,22 @@
+package com.pagoda.matchmeal.mapper;
+
+import com.pagoda.matchmeal.model.entity.Subscription;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
+public interface SubscriptionMapper {
+
+    /**
+     * 오늘이 결제 예정일이거나 이미 지난 'ACTIVE' 상태의 구독 목록을 조회합니다.
+     */
+    List<Subscription> findSubscriptionsToBill(LocalDate today);
+
+    void insertSubscription(Subscription subscription);
+    Subscription findActiveSubscriptionByUserId(Long userId);
+    void updateNextBilling(Subscription subscription);
+
+    void updateSubscriptionStatus(Subscription subscription);
+}

--- a/src/main/java/com/pagoda/matchmeal/mapper/SubscriptionMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/SubscriptionMapper.java
@@ -16,6 +16,7 @@ public interface SubscriptionMapper {
 
     void insertSubscription(Subscription subscription);
     Subscription findActiveSubscriptionByUserId(Long userId);
+    Subscription findValidSubscriptionByUserId(Long userId);
     void updateNextBilling(Subscription subscription);
 
     void updateSubscriptionStatus(Subscription subscription);

--- a/src/main/java/com/pagoda/matchmeal/mapper/UserMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/UserMapper.java
@@ -66,4 +66,9 @@ public interface UserMapper {
      * 특정 회원 영구 삭제 (관리자용/즉시삭제)
      */
     void hardDeleteUserById(Long userId);
+
+    /**
+     * 유저 권한 업그레이드
+     */
+    void updateUserRole(User user);
 }

--- a/src/main/java/com/pagoda/matchmeal/model/dto/response/KakaoApproveResponse.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/response/KakaoApproveResponse.java
@@ -1,0 +1,54 @@
+package com.pagoda.matchmeal.model.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class KakaoApproveResponse {
+    private String aid;                  // 요청 고유 번호
+    private String tid;                  // 결제 고유 번호
+    private String cid;                  // 가맹점 코드
+    private String sid;                  // ★ 정기 결제용 ID (이후 자동결제 시 필수)
+    private String partner_order_id;      // 가맹점 주문번호
+    private String partner_user_id;       // 가맹점 회원 id
+    private String payment_method_type;   // 결제 수단 (CARD 또는 MONEY)
+    private String item_name;             // 상품 이름
+    private Integer quantity;             // 상품 수량
+    private Amount amount;                // 결제 금액 정보
+    private CardInfo card_info;           // 카드 상세 정보 (결제 수단이 카드일 때만)
+    private LocalDateTime created_at;      // 결제 준비 요청 시각
+    private LocalDateTime approved_at;     // 결제 승인 시각
+
+    // 금액 상세 정보 내부 클래스
+    @Getter @Setter @ToString
+    public static class Amount {
+        private Integer total;            // 전체 결제 금액
+        private Integer tax_free;         // 비과세 금액
+        private Integer vat;              // 부가세 금액
+        private Integer point;            // 사용한 포인트 금액
+        private Integer discount;         // 할인 금액
+        private Integer green_deposit;    // 컵 보증금
+    }
+
+    // 카드 상세 정보 내부 클래스
+    @Getter @Setter @ToString
+    public static class CardInfo {
+        private String kakaopay_purchase_corp;      // 카카오페이 매입사명
+        private String kakaopay_purchase_corp_code; // 카카오페이 매입사 코드
+        private String kakaopay_issuer_corp;        // 카카오페이 발급사명
+        private String kakaopay_issuer_corp_code;   // 카카오페이 발급사 코드
+        private String bin;                         // 카드 BIN
+        private String card_type;                   // 카드 타입
+        private String install_month;               // 할부 개월 수
+        private String approved_id;                 // 카드사 승인번호
+        private String card_mid;                    // 카드사 가맹점 번호
+        private String interest_free_install;       // 무이자할부 여부
+        private String installment_type;            // 할부 유형
+    }
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/response/KakaoReadyResponse.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/response/KakaoReadyResponse.java
@@ -1,0 +1,20 @@
+package com.pagoda.matchmeal.model.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+public class KakaoReadyResponse {
+    private String tid;                  // 결제 고유 번호
+    private String next_redirect_app_url;  // 모바일 앱용 리다이렉트 URL
+    private String next_redirect_mobile_url; // 모바일 웹용 리다이렉트 URL
+    private String next_redirect_pc_url;     // PC 웹용 리다이렉트 URL
+    private String android_app_scheme;
+    private String ios_app_scheme;
+    private LocalDateTime created_at;      // 결제 준비 요청 시간
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/response/SubscriptionResponseDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/response/SubscriptionResponseDto.java
@@ -1,0 +1,15 @@
+package com.pagoda.matchmeal.model.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class SubscriptionResponseDto {
+    private String status;          // ACTIVE, INACTIVE
+    private LocalDate nextBillingDate; // 다음 결제 예정일
+    private String itemName;        // 상품명
+    private Integer amount;         // 결제 금액
+}

--- a/src/main/java/com/pagoda/matchmeal/model/entity/Subscription.java
+++ b/src/main/java/com/pagoda/matchmeal/model/entity/Subscription.java
@@ -13,6 +13,7 @@ public class Subscription {
     private Long subscriptionId;
     private Long userId;
     private String sid;            // 카카오페이 정기 결제 키
+    private String cid;            // 가맹점 코드 (TCSUBSCRIP)
     private String tid;            // 결제 고유 번호
     private String partnerOrderId;  // 가맹점 주문번호
     private String itemName;        // 상품명

--- a/src/main/java/com/pagoda/matchmeal/model/entity/Subscription.java
+++ b/src/main/java/com/pagoda/matchmeal/model/entity/Subscription.java
@@ -1,0 +1,23 @@
+package com.pagoda.matchmeal.model.entity;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Subscription {
+    private Long subscriptionId;
+    private Long userId;
+    private String sid;            // 카카오페이 정기 결제 키
+    private String tid;            // 결제 고유 번호
+    private String partnerOrderId;  // 가맹점 주문번호
+    private String itemName;        // 상품명
+    private Integer amount;         // 결제 금액
+    private String status;          // ACTIVE, INACTIVE
+    private LocalDateTime lastApprovedAt; // 마지막 결제 승인 시각
+    private LocalDateTime nextBillingAt; // 다음 결제 예정일
+}

--- a/src/main/java/com/pagoda/matchmeal/scheduler/BillingScheduler.java
+++ b/src/main/java/com/pagoda/matchmeal/scheduler/BillingScheduler.java
@@ -1,0 +1,42 @@
+package com.pagoda.matchmeal.scheduler;
+
+import com.pagoda.matchmeal.mapper.SubscriptionMapper;
+import com.pagoda.matchmeal.model.entity.Subscription;
+import com.pagoda.matchmeal.service.KakaoPayService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BillingScheduler {
+
+    private final KakaoPayService kakaoPayService;
+    private final SubscriptionMapper subscriptionMapper;
+
+    /**
+     * 매일 오전 9시에 실행되어 정기 결제 대상자에게 결제를 요청합니다.
+     */
+    @Scheduled(cron = "0 0 9 * * *")
+    public void executeAutoBilling() {
+        LocalDate today = LocalDate.now();
+        List<Subscription> targetList = subscriptionMapper.findSubscriptionsToBill(today);
+
+        for (Subscription sub : targetList) {
+            try {
+                // 정기 결제 시도
+                kakaoPayService.executeRecurringPayment(sub);
+            } catch (Exception e) {
+                log.error("결제 실패 또는 기한 만료 - 유저 ID: {}, 사유: {}", sub.getUserId(), e.getMessage());
+
+                // 결제 실패 시 즉시 일반 유저로 강등 (한 달 기한 만료 처리)
+                kakaoPayService.demoteUser(sub);
+            }
+        }
+    }
+}

--- a/src/main/java/com/pagoda/matchmeal/service/KakaoPayService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/KakaoPayService.java
@@ -1,0 +1,195 @@
+package com.pagoda.matchmeal.service;
+
+import com.pagoda.matchmeal.common.exception.CustomException;
+import com.pagoda.matchmeal.common.exception.ErrorResponseCode;
+import com.pagoda.matchmeal.mapper.SubscriptionMapper;
+import com.pagoda.matchmeal.mapper.UserMapper;
+import com.pagoda.matchmeal.model.dto.response.KakaoApproveResponse;
+import com.pagoda.matchmeal.model.dto.response.KakaoReadyResponse;
+import com.pagoda.matchmeal.model.entity.Subscription;
+import com.pagoda.matchmeal.model.entity.User;
+import com.pagoda.matchmeal.model.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoPayService {
+    private final UserMapper userMapper;
+    private final SubscriptionMapper subscriptionMapper;
+    private final RestTemplate restTemplate;
+
+    private final Map<Long, String> tidCache = new HashMap<>();
+
+    @Value("${kakaopay.admin-key}") // application.yml에 설정 필요
+    private String adminKey;
+
+    /**
+     * 1. 결제 준비 요청 (Ready)
+     * 사용자가 '구독하기'를 눌렀을 때 호출되어 카카오 결제 URL을 반환합니다.
+     */
+    public KakaoReadyResponse ready(Long userId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("cid", "TCSUBSCRIP");
+        params.put("partner_order_id", "sub_order_" + userId);
+        params.put("partner_user_id", String.valueOf(userId));
+        params.put("item_name", "매치밀 정기구독");
+        params.put("quantity", 1);
+        params.put("total_amount", 9900);
+        params.put("tax_free_amount", 0);
+        params.put("approval_url", "http://localhost:8080/payment/success?userId=" + userId);
+        params.put("cancel_url", "http://localhost:8080/payment/cancel");
+        params.put("fail_url", "http://localhost:8080/payment/fail");
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, getHeaders());
+
+        KakaoReadyResponse response = restTemplate.postForObject(
+                "https://open-api.kakaopay.com/online/v1/payment/ready",
+                request, KakaoReadyResponse.class);
+
+        if (response != null) {
+            // ★ 중요: 나중에 승인(Approve)할 때 쓰기 위해 tid를 임시 저장합니다.
+            tidCache.put(userId, response.getTid());
+        }
+        return response;
+    }
+
+    /**
+     * 2. 첫 결제 승인 및 SID 발급 (Approve)
+     */
+    @Transactional
+    public void approveFirstPayment(String pgToken, Long userId) {
+        // ★ 중요: 저장해뒀던 tid를 꺼내옵니다.
+        String tid = tidCache.get(userId);
+        if (tid == null) throw new CustomException(ErrorResponseCode.PAYMENT_TID_NOT_FOUND);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("cid", "TCSUBSCRIP");
+        params.put("tid", tid); // 꺼내온 tid 사용
+        params.put("partner_order_id", "sub_order_" + userId);
+        params.put("partner_user_id", String.valueOf(userId));
+        params.put("pg_token", pgToken);
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, getHeaders());
+
+        KakaoApproveResponse response = restTemplate.postForObject(
+                "https://open-api.kakaopay.com/online/v1/payment/approve",
+                request, KakaoApproveResponse.class);
+
+        if (response != null && response.getSid() != null) {
+            // 구독 정보 저장
+            Subscription sub = Subscription.builder()
+                    .userId(userId)
+                    .sid(response.getSid())
+                    .tid(response.getTid())
+                    .partnerOrderId(response.getPartner_order_id())
+                    .itemName(response.getItem_name())
+                    .amount(response.getAmount().getTotal())
+                    .status("ACTIVE")
+                    .lastApprovedAt(response.getApproved_at())
+                    .nextBillingAt(response.getApproved_at().plusMonths(1))
+                    .build();
+            subscriptionMapper.insertSubscription(sub);
+
+            // 유저 권한 변경
+            User user = userMapper.findById(userId)
+                    .orElseThrow(() -> new CustomException(ErrorResponseCode.USER_NOT_FOUND));
+            user.setRole(UserRole.ROLE_SUBSCRIBER);
+            userMapper.updateUserRole(user);
+
+            // 사용한 tid는 캐시에서 삭제
+            tidCache.remove(userId);
+        }
+    }
+
+    /**
+     * 3. 정기 결제 요청 (Subscription)
+     */
+    @Transactional
+    public void executeRecurringPayment(Subscription sub) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("cid", "TCSUBSCRIP");
+        params.put("sid", sub.getSid());
+        params.put("partner_order_id", "sub_order_" + sub.getUserId() + "_" + System.currentTimeMillis());
+        params.put("partner_user_id", String.valueOf(sub.getUserId()));
+        params.put("item_name", sub.getItemName());
+        params.put("quantity", 1);
+        params.put("total_amount", sub.getAmount());
+        params.put("tax_free_amount", 0);
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, getHeaders());
+
+        KakaoApproveResponse response = restTemplate.postForObject(
+                "https://open-api.kakaopay.com/online/v1/payment/subscription",
+                request, KakaoApproveResponse.class);
+
+        if (response != null) {
+            sub.setTid(response.getTid());
+            sub.setLastApprovedAt(response.getApproved_at());
+            sub.setNextBillingAt(response.getApproved_at().plusMonths(1));
+            subscriptionMapper.updateNextBilling(sub);
+        }
+    }
+
+    private HttpHeaders getHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "SECRET_KEY " + adminKey);
+        headers.set("Content-Type", "application/json");
+        return headers;
+    }
+
+    /**
+     * 4. 구독 해지 (Cancel)
+     */
+    @Transactional
+    public void cancelSubscription(Long userId) {
+        // 1. 해당 유저의 활성 구독 정보 조회
+        Subscription sub = subscriptionMapper.findActiveSubscriptionByUserId(userId);
+        if (sub == null) throw new CustomException(ErrorResponseCode.SUBSCRIPTION_NOT_FOUND);
+
+        // 2. 카카오페이 정기결제 비활성화(Inactive) API 호출
+        Map<String, Object> params = new HashMap<>();
+        params.put("cid", "TCSUBSCRIP");
+        params.put("sid", sub.getSid());
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, getHeaders());
+
+        // 카카오 서버에 비활성화 요청 (응답은 성공 여부만 확인)
+        restTemplate.postForObject(
+                "https://open-api.kakaopay.com/online/v1/payment/manage/subscription/inactive",
+                request, Map.class);
+
+        // 3. DB 상태 변경: 구독을 INACTIVE로 변경
+        sub.setStatus("INACTIVE");
+        subscriptionMapper.updateSubscriptionStatus(sub);
+
+        // 4. 유저 권한을 다시 ROLE_USER로 변경
+        User user = userMapper.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorResponseCode.USER_NOT_FOUND));
+        user.setRole(UserRole.ROLE_USER);
+        userMapper.updateUserRole(user);
+    }
+
+    /**
+     * 5. 결제 실패 또는 만료 시 권한 강등 처리 (Batch 전용)
+     */
+    @Transactional
+    public void demoteUser(Subscription sub) {
+        sub.setStatus("INACTIVE");
+        subscriptionMapper.updateSubscriptionStatus(sub);
+
+        User user = userMapper.findById(sub.getUserId()).orElse(null);
+        if (user != null) {
+            user.setRole(UserRole.ROLE_USER);
+            userMapper.updateUserRole(user);
+        }
+    }
+}

--- a/src/main/java/com/pagoda/matchmeal/service/KakaoPayService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/KakaoPayService.java
@@ -45,9 +45,9 @@ public class KakaoPayService {
         params.put("quantity", 1);
         params.put("total_amount", 9900);
         params.put("tax_free_amount", 0);
-        params.put("approval_url", "http://localhost:8080/payment/success?userId=" + userId);
-        params.put("cancel_url", "http://localhost:8080/payment/cancel");
-        params.put("fail_url", "http://localhost:8080/payment/fail");
+        params.put("approval_url", "http://localhost:5173/payment/success?userId=" + userId);
+        params.put("cancel_url", "http://localhost:5173/subscription");
+        params.put("fail_url", "http://localhost:5173/subscription");
 
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, getHeaders());
 
@@ -89,6 +89,7 @@ public class KakaoPayService {
             Subscription sub = Subscription.builder()
                     .userId(userId)
                     .sid(response.getSid())
+                    .cid("TCSUBSCRIP") // CID 설정 추가
                     .tid(response.getTid())
                     .partnerOrderId(response.getPartner_order_id())
                     .itemName(response.getItem_name())
@@ -155,27 +156,29 @@ public class KakaoPayService {
         Subscription sub = subscriptionMapper.findActiveSubscriptionByUserId(userId);
         if (sub == null) throw new CustomException(ErrorResponseCode.SUBSCRIPTION_NOT_FOUND);
 
-        // 2. 카카오페이 정기결제 비활성화(Inactive) API 호출
-        Map<String, Object> params = new HashMap<>();
-        params.put("cid", "TCSUBSCRIP");
-        params.put("sid", sub.getSid());
+        // 2. 카카오페이 API 호출 제거 (SID 살려두기 위함 - 재구독 시 그대로 사용)
+        // 나중에 완전히 만료되면 그때 Inactive 호출하거나, 그냥 스케줄러에서 요청 안하면 됨.
 
-        HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, getHeaders());
-
-        // 카카오 서버에 비활성화 요청 (응답은 성공 여부만 확인)
-        restTemplate.postForObject(
-                "https://open-api.kakaopay.com/online/v1/payment/manage/subscription/inactive",
-                request, Map.class);
-
-        // 3. DB 상태 변경: 구독을 INACTIVE로 변경
-        sub.setStatus("INACTIVE");
+        // 3. DB 상태 변경: 구독을 CANCELED로 변경 (다음 결제일까지 이용 가능)
+        sub.setStatus("CANCELED");
         subscriptionMapper.updateSubscriptionStatus(sub);
+    }
 
-        // 4. 유저 권한을 다시 ROLE_USER로 변경
-        User user = userMapper.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorResponseCode.USER_NOT_FOUND));
-        user.setRole(UserRole.ROLE_USER);
-        userMapper.updateUserRole(user);
+    /**
+     * 6. 구독 재활성화 (Reactivate)
+     * - 해지 신청했으나 아직 만료되지 않은 유저가 다시 구독 유지할 때
+     */
+    @Transactional
+    public void reactivateSubscription(Long userId) {
+        Subscription sub = subscriptionMapper.findValidSubscriptionByUserId(userId);
+        // CANCELED 상태이고, 아직 기간이 남은 경우에만 가능
+        if (sub == null || !"CANCELED".equals(sub.getStatus())) {
+             throw new CustomException(ErrorResponseCode.INVALID_REQUEST);
+        }
+
+        // 상태를 다시 ACTIVE로 복구
+        sub.setStatus("ACTIVE");
+        subscriptionMapper.updateSubscriptionStatus(sub);
     }
 
     /**
@@ -191,5 +194,25 @@ public class KakaoPayService {
             user.setRole(UserRole.ROLE_USER);
             userMapper.updateUserRole(user);
         }
+    }
+
+    /**
+     * 내 구독 정보 조회
+     */
+    public com.pagoda.matchmeal.model.dto.response.SubscriptionResponseDto getMySubscription(Long userId) {
+        Subscription subscription = subscriptionMapper.findValidSubscriptionByUserId(userId);
+
+        if (subscription == null) {
+            return com.pagoda.matchmeal.model.dto.response.SubscriptionResponseDto.builder()
+                    .status("INACTIVE")
+                    .build();
+        }
+
+        return com.pagoda.matchmeal.model.dto.response.SubscriptionResponseDto.builder()
+                .status(subscription.getStatus())
+                .nextBillingDate(subscription.getNextBillingAt().toLocalDate())
+                .itemName(subscription.getItemName())
+                .amount(subscription.getAmount())
+                .build();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ spring.datasource.url=jdbc:mysql://matchmeal-project.chmge8kcwil3.ap-northeast-2
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=${RDS_USERNAME}
 spring.datasource.password=${RDS_PASSWORD}
-spring.sql.init.mode=never
+spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.data-locations=classpath:data.sql
 spring.sql.init.encoding=UTF-8
@@ -29,7 +29,7 @@ mybatis.type-aliases-package=com.pagoda.matchmeal.model.entity
 logging.level.com.pagoda.matchmeal.mapper=DEBUG
 ## 테스트용
 # 배치 작업 수동 run ( 실 서버에서는 true )
-spring.batch.job.enabled=false
+spring.batch.job.enabled=true
 # Spring Batch가 사용하는 메타 테이블(BATCH_JOB_...)을 H2에 자동 생성
 spring.batch.jdbc.initialize-schema=always
 # google
@@ -71,3 +71,5 @@ spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
 ai.url=http://127.0.0.1:8000/vision/analyze
+
+kakaopay.admin.key={KAKAOPAY_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -72,7 +72,7 @@ spring.data.redis.port=6379
 
 ai.url=http://127.0.0.1:8000/vision/analyze
 
-kakaopay.admin.key={KAKAOPAY_SECRET_KEY}
+kakaopay.admin-key=${KAKAOPAY_SECRET_KEY}
 springdoc.api-docs.enabled=true
 springdoc.show-actuator=true
 springdoc.override-with-generic-response=true

--- a/src/main/resources/mappers/SubscriptionMapper.xml
+++ b/src/main/resources/mappers/SubscriptionMapper.xml
@@ -7,6 +7,7 @@
         INSERT INTO user_subscriptions (
             user_id,
             sid,
+            cid,
             tid,
             partner_order_id,
             item_name,
@@ -19,6 +20,7 @@
         ) VALUES (
             #{userId},
             #{sid},
+            #{cid},
             #{tid},
             #{partnerOrderId},
             #{itemName},
@@ -46,6 +48,25 @@
         FROM user_subscriptions
         WHERE user_id = #{userId}
           AND status = 'ACTIVE'
+        ORDER BY created_at DESC
+            LIMIT 1
+    </select>
+
+    <select id="findValidSubscriptionByUserId" resultType="com.pagoda.matchmeal.model.entity.Subscription">
+        SELECT
+            subscription_id   AS subscriptionId,
+            user_id           AS userId,
+            sid,
+            tid,
+            partner_order_id  AS partnerOrderId,
+            item_name         AS itemName,
+            total_amount      AS amount,
+            status,
+            last_approved_at  AS lastApprovedAt,
+            next_billing_date AS nextBillingAt
+        FROM user_subscriptions
+        WHERE user_id = #{userId}
+          AND status IN ('ACTIVE', 'CANCELED')
         ORDER BY created_at DESC
             LIMIT 1
     </select>

--- a/src/main/resources/mappers/SubscriptionMapper.xml
+++ b/src/main/resources/mappers/SubscriptionMapper.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.pagoda.matchmeal.mapper.SubscriptionMapper">
+
+    <insert id="insertSubscription" useGeneratedKeys="true" keyProperty="subscriptionId">
+        INSERT INTO user_subscriptions (
+            user_id,
+            sid,
+            tid,
+            partner_order_id,
+            item_name,
+            total_amount,
+            status,
+            last_approved_at,
+            next_billing_date,
+            created_at,
+            updated_at
+        ) VALUES (
+            #{userId},
+            #{sid},
+            #{tid},
+            #{partnerOrderId},
+            #{itemName},
+            #{amount},
+            #{status},
+            #{lastApprovedAt},
+            #{nextBillingAt},
+            NOW(),
+            NOW()
+        )
+    </insert>
+
+    <select id="findActiveSubscriptionByUserId" resultType="com.pagoda.matchmeal.model.entity.Subscription">
+        SELECT
+            subscription_id   AS subscriptionId,
+            user_id           AS userId,
+            sid,
+            tid,
+            partner_order_id  AS partnerOrderId,
+            item_name         AS itemName,
+            total_amount      AS amount,
+            status,
+            last_approved_at  AS lastApprovedAt,
+            next_billing_date AS nextBillingAt
+        FROM user_subscriptions
+        WHERE user_id = #{userId}
+          AND status = 'ACTIVE'
+        ORDER BY created_at DESC
+            LIMIT 1
+    </select>
+
+    <update id="updateNextBilling">
+        UPDATE user_subscriptions
+        SET
+            tid = #{tid},
+            last_approved_at = #{lastApprovedAt},
+            next_billing_date = #{nextBillingAt},
+            updated_at = NOW()
+        WHERE subscription_id = #{subscriptionId}
+          AND status = 'ACTIVE'
+    </update>
+
+    <select id="findSubscriptionsToBill" resultType="com.pagoda.matchmeal.model.entity.Subscription">
+        SELECT
+            subscription_id   AS subscriptionId,
+            user_id           AS userId,
+            sid,
+            tid,
+            partner_order_id  AS partnerOrderId,
+            item_name         AS itemName,
+            total_amount      AS amount,
+            status,
+            last_approved_at  AS lastApprovedAt,
+            next_billing_date AS nextBillingAt
+        FROM user_subscriptions
+        WHERE status = 'ACTIVE'                -- 1. 활성화된 구독만 대상
+          AND next_billing_date &lt;= #{today}  -- 2. 결제 예정일이 오늘이거나 이미 지난 경우
+        ORDER BY next_billing_date ASC         -- 3. 오래된 순서부터 정렬
+    </select>
+
+    <update id="updateSubscriptionStatus">
+        UPDATE user_subscriptions
+        SET
+            status = #{status},
+            updated_at = NOW()
+        WHERE subscription_id = #{subscriptionId}
+    </update>
+</mapper>

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -85,4 +85,13 @@
         WHERE user_id = #{userId}
     </delete>
 
+    <update id="updateUserRole">
+        UPDATE users
+        SET
+            role = #{role},
+            updated_at = NOW()
+        WHERE user_id = #{userId}
+          AND deleted_at IS NULL
+    </update>
+
 </mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -306,11 +306,15 @@ CREATE TABLE user_subscriptions (
                                     user_id           BIGINT NOT NULL,
                                     sid               VARCHAR(100) NOT NULL, -- 정기 결제 고유번호 (SID)
                                     cid               VARCHAR(20) NOT NULL,  -- 가맹점 코드 (TCSUBSCRIP)
+                                    tid               VARCHAR(100),          -- [추가] 결제 고유 번호 (결제 승인 후 저장)
+                                    partner_order_id  VARCHAR(100),          -- [추가] 가맹점 주문번호
                                     item_name         VARCHAR(100),          -- 상품명
                                     total_amount      INT NOT NULL,          -- 결제 금액
                                     status            VARCHAR(20) DEFAULT 'ACTIVE', -- ACTIVE, INACTIVE
+                                    last_approved_at  DATETIME,              -- [추가] 마지막 결제 승인 시각
                                     next_billing_date DATE,                  -- 다음 결제 예정일
                                     created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                    updated_at        TIMESTAMP,             -- [추가] 정보 수정 시각
 
     -- [핵심] 유저 탈퇴 시 구독 정보도 삭제 (결제 보안 및 데이터 정합성)
                                     CONSTRAINT fk_sub_user FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -15,6 +15,9 @@ DROP TABLE IF EXISTS diet_details;
 DROP TABLE IF EXISTS diet_records;
 DROP TABLE IF EXISTS foods;
 
+DROP TABLE IF EXISTS notifications;
+DROP TABLE IF EXISTS user_subscriptions;
+
 DROP TABLE IF EXISTS follows;
 DROP TABLE IF EXISTS users;
 
@@ -297,8 +300,6 @@ CREATE INDEX idx_noti_receiver_read ON notifications (receiver_id, is_read);
 
 
 -- 11. 정기 결제 정보 테이블 (기존 테이블 수정 버전)
--- 테이블이 이미 존재할 경우를 대비해 DROP 후 재생성 로직 권장
-DROP TABLE IF EXISTS user_subscriptions;
 
 CREATE TABLE user_subscriptions (
                                     subscription_id   BIGINT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
### 📋 개요 (Summary)

카카오페이 정기결제 API를 연동하여 멤버십 결제 시스템을 구축하고, 구독의 생성·해지·재활성화를 아우르는 **구독 수명주기 관리 로직**을 구현했습니다. 특히 사용자가 해지를 요청하더라도 유료 결제 기간 동안은 권한을 유지하는 **Soft Cancellation** 구조를 채택하여 사용자 경험을 최적화했습니다.

### 🛠 핵심 구현 사항 (Implementation Details)

#### 1. 🤖 KakaoPayService: 정기결제 및 상태 관리 로직

* **Payment Flow:** `ready(결제 준비)`와 `approve(최종 승인)` 단계를 구현하여 정기결제 핵심 키인 **SID(Subscription ID)**를 성공적으로 발급 및 저장합니다.
* **Soft Cancellation (유예 해지):** 사용자가 해지를 요청할 경우 즉시 카카오페이 SID를 비활성화하지 않고, DB 상태만 `CANCELED`로 변경합니다. 이를 통해 차기 결제일(`nextBillingDate`)까지 구독 권한을 보장합니다.
* **Reactivation (재활성화):** `CANCELED` 상태(해지 대기)인 유저가 결제일 전에 마음을 바꿀 경우, 추가 결제 없이 상태만 `ACTIVE`로 복구하여 구독을 유지하는 기능을 추가했습니다.

#### 2. 🔒 Security & API 엔드포인트

* **권한 제어:** `SecurityConfig` 설정을 통해 AI 피드백 등 핵심 기능(`api/ai/**`)의 접근 권한을 `ROLE_SUBSCRIBER`로 제한하여 비즈니스 모델을 보호합니다.
* **API 확장:** * `POST /payment/reactivate`: 해지 대기 중인 구독을 다시 활성화.
* `POST /payment/cancel`: Soft Cancellation 로직이 반영된 해지 요청.
* `GET /payment/success`: 결제 성공 후 SID 저장 및 권한 상향 로직 처리.



#### 3. 💾 데이터 모델링 및 매퍼 (Data & Mapper)

* **스키마 고도화:** `user_subscriptions` 테이블에 카카오페이 연동에 필요한 필드(`cid`, `tid`, `partner_order_id` 등)를 추가하여 데이터 정합성을 높였습니다.
* **MyBatis 쿼리 최적화:** `findValidSubscriptionByUserId` 쿼리를 추가하여 현재 `ACTIVE` 혹은 `CANCELED`(해지 대기) 상태인 유효 구독 정보를 정확히 판별합니다.

### 🔍 주요 로직 워크플로우

1. **결제 승인:** `approve` 시점에 유저 권한을 `ROLE_SUBSCRIBER`로 즉시 변경합니다.
2. **해지 요청:** 해지 시에도 권한은 유지되며, `BillingScheduler`가 결제일에 `CANCELED` 상태를 확인하여 결제를 중단하고 권한을 `ROLE_USER`로 회수합니다.
3. **기능 제한:** 일반 유저가 AI 기능을 요청할 경우 `SecurityConfig`에 의해 접근이 차단됩니다.

### ✅ 검증 결과 (Verification)

* [x] **결제 프로세스:** Ready → Approve 과정을 통해 SID가 DB에 정상 저장되는지 확인.
* [x] **Soft Cancel 테스트:** 해지 후에도 만료일 전까지 `ROLE_SUBSCRIBER` 권한이 유지되는지 확인.
* [x] **Reactivate 테스트:** 해지 대기 상태에서 재활성화 시 결제 없이 상태가 복구되는지 확인.
* [x] **보안 테스트:** `ROLE_USER` 권한으로 `/ai/**` 엔드포인트 접근 시 403 Forbidden 응답 확인.