### PR TITLE
Feature : 알림 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 // 단위 테스트만 돌리도록 설정 (develop 용)

--- a/src/main/java/com/pagoda/matchmeal/common/config/SecurityConfig.java
+++ b/src/main/java/com/pagoda/matchmeal/common/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
                         .requestMatchers("/ai/**").hasAnyRole("SUBSCRIBER", "ADMIN") // ★ AI 기능은 구독자만 접근 가능 + 관리자
                         .requestMatchers("/payment/**").hasAnyRole("USER", "SUBSCRIBER", "ADMIN") // 결제 관련 접근 허용 + 관리자
                         .requestMatchers("/auth/**").permitAll()
-                        .requestMatchers("/css/**", "/images/**", "/js/**", "/login/**", "/favicon.ico", "/error").permitAll()
+                        .requestMatchers("/css/**", "/images/**", "/js/**", "/login/**", "/favicon.ico", "/error", "/ws-stomp/**").permitAll()
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",

--- a/src/main/java/com/pagoda/matchmeal/common/config/WebSocketConfig.java
+++ b/src/main/java/com/pagoda/matchmeal/common/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package com.pagoda.matchmeal.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 1. 클라이언트 연결 엔드포인트: ws://localhost:8080/ws-stomp
+        registry.addEndpoint("/ws-stomp")
+                .setAllowedOriginPatterns("*") // CORS 허용
+                .withSockJS(); // SockJS 지원 (브라우저 호환성)
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 2. 메시지 구독 요청 url (클라이언트가 듣는 곳)
+        // /topic: 전체 알림 (공지, 아침 알림)
+        // /queue: 개인 알림 (팔로잉, 좋아요)
+        registry.enableSimpleBroker("/topic", "/queue");
+    }
+}

--- a/src/main/java/com/pagoda/matchmeal/controller/NotificationController.java
+++ b/src/main/java/com/pagoda/matchmeal/controller/NotificationController.java
@@ -1,0 +1,44 @@
+package com.pagoda.matchmeal.controller;
+
+import com.pagoda.matchmeal.common.response.CommonResponse;
+import com.pagoda.matchmeal.common.util.ApiResponseUtil;
+import com.pagoda.matchmeal.model.dto.NotificationDto;
+import com.pagoda.matchmeal.model.dto.UserDto;
+import com.pagoda.matchmeal.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/notification")
+    public CommonResponse<List<NotificationDto>> getMyNotifications(@AuthenticationPrincipal UserDto userDto) {
+        return ApiResponseUtil.success(notificationService.getMyNotifications(userDto.getId()));
+    }
+
+    @GetMapping("/notification/unread-count")
+    public CommonResponse<Integer> getUnreadNotifications(@AuthenticationPrincipal UserDto userDto) {
+        return ApiResponseUtil.success(notificationService.getUnreadCount(userDto.getId()));
+    }
+
+    @PatchMapping("/notification/{notificationId}/read")
+    public CommonResponse<Void> markAsRead(
+            @PathVariable("notificationId") Long notificationId,
+            @AuthenticationPrincipal UserDto userDto
+    ) {
+        notificationService.markAsRead(notificationId);
+        return ApiResponseUtil.success();
+    }
+
+    @DeleteMapping("/notification")
+    public CommonResponse<Void> deleteNotification(@AuthenticationPrincipal UserDto userDto) {
+        notificationService.deleteAll(userDto.getId());
+        return ApiResponseUtil.success();
+    }
+}

--- a/src/main/java/com/pagoda/matchmeal/mapper/FollowMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/FollowMapper.java
@@ -53,4 +53,6 @@ public interface FollowMapper {
      * @param viewerId 현재 목록을 보는 사람 (맞팔 여부 확인용)
      */
     List<FollowListDto> getFollowings(@Param("targetId") Long targetId, @Param("viewerId") Long viewerId);
+
+    List<Long> findFollowerIds(Long userId);
 }

--- a/src/main/java/com/pagoda/matchmeal/mapper/NotificationMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/NotificationMapper.java
@@ -1,0 +1,25 @@
+package com.pagoda.matchmeal.mapper;
+
+import com.pagoda.matchmeal.model.dto.NotificationDto;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+public interface NotificationMapper {
+    // 알림 저장
+    void save(NotificationDto notificationDto);
+
+    // 내 알림 목록 조회 (보낸 사람 정보 JOIN 포함)
+    List<NotificationDto> findByReceiverId(@Param("receiverId") Long receiverId);
+
+    // 알림 읽음 처리
+    void markAsRead(@Param("notificationId") Long notificationId);
+
+    // 안 읽은 알림 개수 (뱃지용)
+    int countUnread(@Param("receiverId") Long receiverId);
+
+    // 특정 기간 이전의 읽은 알림 삭제 (DB 용량 관리용)
+    void deleteOldNotifications(@Param("days") int days);
+
+    void deleteAllByReceiverId(@Param("receiverId") Long receiverId);
+}

--- a/src/main/java/com/pagoda/matchmeal/mapper/SubscriptionMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/SubscriptionMapper.java
@@ -1,5 +1,6 @@
 package com.pagoda.matchmeal.mapper;
 
+import com.pagoda.matchmeal.model.dto.SubscriptionAlertDto;
 import com.pagoda.matchmeal.model.entity.Subscription;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -15,9 +16,14 @@ public interface SubscriptionMapper {
     List<Subscription> findSubscriptionsToBill(LocalDate today);
 
     void insertSubscription(Subscription subscription);
+
     Subscription findActiveSubscriptionByUserId(Long userId);
+
     Subscription findValidSubscriptionByUserId(Long userId);
+
     void updateNextBilling(Subscription subscription);
 
     void updateSubscriptionStatus(Subscription subscription);
+
+    List<SubscriptionAlertDto> findUsersWithUpcomingPayment();
 }

--- a/src/main/java/com/pagoda/matchmeal/mapper/UserMapper.java
+++ b/src/main/java/com/pagoda/matchmeal/mapper/UserMapper.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -71,4 +72,6 @@ public interface UserMapper {
      * 유저 권한 업그레이드
      */
     void updateUserRole(User user);
+
+    List<Long> findAllActiveUserIds();
 }

--- a/src/main/java/com/pagoda/matchmeal/model/dto/NotificationDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/NotificationDto.java
@@ -1,0 +1,31 @@
+package com.pagoda.matchmeal.model.dto;
+
+import com.pagoda.matchmeal.model.enums.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationDto {
+
+    private Long notificationId;
+    private Long receiverId;
+    private Long senderId;
+    private String senderName;
+    private String senderProfileImage;
+
+    private NotificationType notificationType;
+    private String content;
+
+    private int relatedId;
+    private String relatedUrl;
+
+    private boolean isRead;
+
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/pagoda/matchmeal/model/dto/SubscriptionAlertDto.java
+++ b/src/main/java/com/pagoda/matchmeal/model/dto/SubscriptionAlertDto.java
@@ -1,0 +1,14 @@
+package com.pagoda.matchmeal.model.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubscriptionAlertDto {
+
+    private Long userId;
+    private int dDay;
+}

--- a/src/main/java/com/pagoda/matchmeal/model/enums/NotificationType.java
+++ b/src/main/java/com/pagoda/matchmeal/model/enums/NotificationType.java
@@ -1,0 +1,33 @@
+package com.pagoda.matchmeal.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+
+    // 1. 아침 식단 기록 알림
+    DAILY_DIET("식단 기록"),
+
+    // 2. 공지사항
+    NOTICE("공지사항"),
+
+    // 3. 팔로우/팔로잉
+    FOLLOW("팔로우"),
+
+    // 4. 팔로잉 유저 게시물 업로드
+    FOLLOWING_POST("새 게시물"),
+
+    // 5. 게시글 좋아요/댓글
+    POST_LIKE("좋아요"),
+    COMMENT("댓글"),
+
+    // 6. 구독 결제일 알림 (7일전, 3일전, 하루전, 당일 등)
+    PAYMENT_ALERT("결제 알림"),
+
+    // 7. 챌린지 초대
+    CHALLENGE_INVITE("챌린지 초대");
+
+    private final String description;
+}

--- a/src/main/java/com/pagoda/matchmeal/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/pagoda/matchmeal/scheduler/NotificationScheduler.java
@@ -1,0 +1,99 @@
+package com.pagoda.matchmeal.scheduler;
+
+import com.pagoda.matchmeal.mapper.NotificationMapper;
+import com.pagoda.matchmeal.mapper.SubscriptionMapper;
+import com.pagoda.matchmeal.mapper.UserMapper;
+import com.pagoda.matchmeal.model.dto.SubscriptionAlertDto;
+import com.pagoda.matchmeal.model.enums.NotificationType;
+import com.pagoda.matchmeal.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final NotificationService notificationService;
+    private final NotificationMapper notificationMapper;
+    private final UserMapper userMapper;
+    private final SubscriptionMapper subscriptionMapper;
+
+    /**
+     * 1. 매일 아침 8시: 식단 기록 알림
+     * 대상: 탈퇴하지 않은 모든 활성 유저
+     */
+    @Scheduled(cron = "0 0 8 * * *") // 초 분 시 일 월 요일
+    public void sendMorningDietAlert() {
+        log.info("⏰ [Scheduler] 아침 식단 알림 발송 시작");
+
+        List<Long> allActiveUserIds = userMapper.findAllActiveUserIds();
+
+        for (Long userId : allActiveUserIds) {
+            notificationService.sendToUser(
+                    userId,
+                    null,
+                    NotificationType.DAILY_DIET,
+                    "☀️ 좋은 아침입니다! 식단을 기록하며 하루를 건강하게 시작해보세요.",
+                    0,
+                    "/diet/record"
+            );
+        }
+        log.info("✅ [Scheduler] 아침 식단 알림 발송 완료 (총 {}명)", allActiveUserIds.size());
+    }
+
+    /**
+     * 2. 매일 오후 3시: 구독 결제일 임박 알림
+     * 대상: 결제일이 7일, 3일, 1일, 0일(당일) 남은 유저
+     */
+    @Scheduled(cron = "0 0 15 * * *")
+    public void sendSubscriptionPaymentAlert() {
+        log.info("⏰ [Scheduler] 구독 결제일 알림 체크 시작");
+
+        // 1. 결제일이 다가온 유저 조회 (D-Day 포함)
+        List<SubscriptionAlertDto> dueUsers = subscriptionMapper.findUsersWithUpcomingPayment();
+
+        // 2. 알림 전송
+        for (SubscriptionAlertDto user : dueUsers) {
+            String message;
+            if (user.getDDay() == 0) {
+                message = "💳 정기 결제일입니다. 결제 수단을 확인해주세요.";
+            } else {
+                message = "💳 정기 결제일이 " + user.getDDay() + "일 남았습니다.";
+            }
+
+            notificationService.sendToUser(
+                    user.getUserId(),
+                    null,
+                    NotificationType.PAYMENT_ALERT,
+                    message,
+                    0,
+                    "/settings"
+            );
+        }
+        log.info("✅ [Scheduler] 구독 결제 알림 발송 완료 (총 {}명)", dueUsers.size());
+    }
+
+    /**
+     * 3. 매일 새벽 4시: 오래된 알림 데이터 삭제 (DB 정리)
+     * - 조건: 읽음 처리됨(is_read=1) AND 생성된 지 30일 지남
+     */
+    @Scheduled(cron = "0 0 4 * * *") // 매일 새벽 4시 0분 0초 실행
+    public void deleteOldNotifications() {
+        int days = 30; // 30일 지난 데이터 삭제 (정책에 따라 60, 90 등으로 변경 가능)
+
+        log.info("🧹 [Scheduler] 오래된 알림 데이터 정리 시작 (기준: {}일 전)", days);
+
+        // Mapper 호출 (반환값이 삭제된 행의 개수일 경우 활용 가능)
+        try {
+            notificationMapper.deleteOldNotifications(days);
+            log.info("✅ [Scheduler] 오래된 알림 삭제 완료");
+        } catch (Exception e) {
+            log.error("❌ [Scheduler] 알림 삭제 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/pagoda/matchmeal/service/NotificationService.java
+++ b/src/main/java/com/pagoda/matchmeal/service/NotificationService.java
@@ -1,0 +1,21 @@
+package com.pagoda.matchmeal.service;
+
+import com.pagoda.matchmeal.model.dto.NotificationDto;
+import com.pagoda.matchmeal.model.enums.NotificationType;
+
+import java.util.List;
+
+public interface NotificationService {
+
+    void sendToUser(Long receiverId, Long senderId, NotificationType type, String content, int relatedId, String relatedUrl);
+
+    void sendToTopic(NotificationType type, String content, String relatedUrl);
+
+    List<NotificationDto> getMyNotifications(Long userId);
+
+    int getUnreadCount(Long userId);
+
+    void markAsRead(Long notificationId);
+
+    void deleteAll(Long userId);
+}

--- a/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/ChallengeServiceImpl.java
@@ -4,6 +4,7 @@ import com.pagoda.matchmeal.common.exception.CustomException;
 import com.pagoda.matchmeal.common.exception.ErrorResponseCode;
 import com.pagoda.matchmeal.mapper.ChallengeMapper;
 import com.pagoda.matchmeal.mapper.DietMapper;
+import com.pagoda.matchmeal.mapper.UserMapper;
 import com.pagoda.matchmeal.model.dto.ChallengeSearchCondition;
 import com.pagoda.matchmeal.model.dto.request.ChallengeCreateRequestDto;
 import com.pagoda.matchmeal.model.dto.response.*;
@@ -12,8 +13,10 @@ import com.pagoda.matchmeal.model.entity.ChallengeInvitation;
 import com.pagoda.matchmeal.model.entity.Diet;
 import com.pagoda.matchmeal.model.entity.DietDetail;
 import com.pagoda.matchmeal.model.enums.ChallengeType;
+import com.pagoda.matchmeal.model.enums.NotificationType;
 import com.pagoda.matchmeal.service.ChallengeService;
 import com.pagoda.matchmeal.service.FollowService;
+import com.pagoda.matchmeal.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +38,8 @@ public class ChallengeServiceImpl implements ChallengeService {
     private final ChallengeMapper challengeMapper;
     private final FollowService followService;
     private final DietMapper dietMapper;
+    private final UserMapper userMapper;
+    private final NotificationService notificationService;
 
     /**
      * 챌린지 생성
@@ -149,6 +154,19 @@ public class ChallengeServiceImpl implements ChallengeService {
             throw new CustomException(ErrorResponseCode.ALREADY_INVITED);
         }
         challengeMapper.insertInvitation(challengeId, inviterId, targetUserId);
+
+        String inviterName = userMapper.findById(inviterId).orElseThrow(() -> new CustomException(ErrorResponseCode.USER_NOT_FOUND)).getUserName();
+
+        String challengeTitle = challengeMapper.findById(challengeId).getTitle();
+
+        notificationService.sendToUser(
+                targetUserId,
+                inviterId,
+                NotificationType.CHALLENGE_INVITE,
+                inviterName + "님이 [" + challengeTitle + "] 챌린지에 초대했습니다.",
+                challengeId.intValue(),
+                "/challenges/" + challengeId
+        );
     }
 
     /**
@@ -306,7 +324,7 @@ public class ChallengeServiceImpl implements ChallengeService {
             // Rollback
             int newCurrentCount = Math.max(0, uc.getCurrentCount() - 1);
             int newCurrentStreak = Math.max(0, uc.getCurrentStreak() - 1);
-            
+
             // Fix: If rolling back "today", lastSuccessDate check (alreadySucceededToday) relies on this NOT being today.
             // If streak is preserved (was > 1, now > 0), previous success was yesterday.
             // If streak broken (now 0), we set to null to safely clear "today" status.

--- a/src/main/java/com/pagoda/matchmeal/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/CommentServiceImpl.java
@@ -4,11 +4,15 @@ import com.pagoda.matchmeal.common.exception.CustomException;
 import com.pagoda.matchmeal.common.exception.ErrorResponseCode;
 import com.pagoda.matchmeal.mapper.CommentMapper;
 import com.pagoda.matchmeal.mapper.PostMapper;
+import com.pagoda.matchmeal.mapper.UserMapper;
 import com.pagoda.matchmeal.model.dto.request.CommentRequestDto;
 import com.pagoda.matchmeal.model.dto.response.CommentResponseDto;
 import com.pagoda.matchmeal.model.dto.response.PostDetailResponseDto;
 import com.pagoda.matchmeal.model.entity.Comment;
+import com.pagoda.matchmeal.model.entity.User;
+import com.pagoda.matchmeal.model.enums.NotificationType;
 import com.pagoda.matchmeal.service.CommentService;
+import com.pagoda.matchmeal.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +34,8 @@ public class CommentServiceImpl implements CommentService {
 
     private final CommentMapper commentMapper;
     private final PostMapper postMapper;
+    private final UserMapper userMapper;
+    private final NotificationService notificationService;
 
     /**
      * 댓글 작성
@@ -44,9 +50,15 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public Long writeComment(Long userId, Long postId, CommentRequestDto commentRequestDto) {
         validateUser(userId);
-        existingPost(postId);
+
+        PostDetailResponseDto post = postMapper.getPostByPostId(postId);
+        if (post == null) {
+            throw new CustomException(ErrorResponseCode.POST_NOT_FOUND);
+        }
 
         Long parentCommentId = commentRequestDto.getParentCommentId();
+        Long parentCommentAuthorId = null;
+
         if (parentCommentId != null) {
             CommentResponseDto parent = commentMapper.findByCommentId(parentCommentId);
             if (parent == null) {
@@ -56,6 +68,7 @@ public class CommentServiceImpl implements CommentService {
             if (parent.getParentCommentId() != null) {
                 parentCommentId = parent.getParentCommentId();
             }
+            parentCommentAuthorId = parent.getUser().getUserId();
         }
 
         Comment comment = Comment.builder()
@@ -66,6 +79,38 @@ public class CommentServiceImpl implements CommentService {
                 .build();
 
         commentMapper.save(comment);
+
+        // 0. 댓글 작성자 정보 조회 (알림 메시지용)
+        User commenter = userMapper.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorResponseCode.USER_NOT_FOUND));
+
+        // 1. 게시글 작성자에게 알림 (내 글에 내가 댓글 단 경우는 제외)
+        if (!post.getUser().getUserId().equals(userId)) {
+            notificationService.sendToUser(
+                    post.getUser().getUserId(), // 수신자: 글 작성자
+                    userId,                         // 발신자: 댓글 작성자
+                    NotificationType.COMMENT,
+                    commenter.getUserName() + "님이 댓글을 남겼습니다.",
+                    postId.intValue(),              // relatedId
+                    "/community/" + postId          // 이동 경로
+            );
+        }
+
+        // 2. (대댓글인 경우) 원댓글 작성자에게 알림
+        // 조건: 대댓글이어야 함 && 내 댓글에 내가 대댓글 단 경우 제외 && 원댓글 작성자가 글 작성자와 다를 경우(중복 알림 방지)
+        if (parentCommentAuthorId != null
+                && !parentCommentAuthorId.equals(userId)
+                && !parentCommentAuthorId.equals(post.getUser().getUserId())) {
+
+            notificationService.sendToUser(
+                    parentCommentAuthorId,          // 수신자: 원댓글 작성자
+                    userId,                         // 발신자: 대댓글 작성자
+                    NotificationType.COMMENT,
+                    commenter.getUserName() + "님이 대댓글을 남겼습니다.",
+                    postId.intValue(),
+                    "/community/" + postId
+            );
+        }
         return comment.getCommentId();
     }
 

--- a/src/main/java/com/pagoda/matchmeal/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/FollowServiceImpl.java
@@ -6,7 +6,9 @@ import com.pagoda.matchmeal.mapper.FollowMapper;
 import com.pagoda.matchmeal.mapper.UserMapper;
 import com.pagoda.matchmeal.model.dto.response.FollowListDto;
 import com.pagoda.matchmeal.model.dto.response.FollowResponseDto;
+import com.pagoda.matchmeal.model.enums.NotificationType;
 import com.pagoda.matchmeal.service.FollowService;
+import com.pagoda.matchmeal.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +27,7 @@ public class FollowServiceImpl implements FollowService {
 
     private final FollowMapper followMapper;
     private final UserMapper userMapper;
+    private final NotificationService notificationService;
 
     /**
      * 팔로우 토글(이미 팔로우 중이면 취소, 아니면 팔로우
@@ -58,6 +61,17 @@ public class FollowServiceImpl implements FollowService {
         // 갱신된 카운트 조회
         Long targetFollowerCount = followMapper.countFollowers(followingId);
         Long myFollowingCount = followMapper.countFollowings(followerId);
+
+        String followerName = userMapper.findById(followerId).orElseThrow(() -> new CustomException(ErrorResponseCode.USER_NOT_FOUND)).getUserName();
+
+        notificationService.sendToUser(
+                followingId,            // 받는 사람 (팔로우 당한 사람)
+                followerId,             // 보낸 사람 (나)
+                NotificationType.FOLLOW,
+                followerName + "님이 회원님을 팔로우하기 시작했습니다.",
+                followerId.intValue(),  // 클릭 시 상대방 프로필로 이동
+                "/users/" + followerId
+        );
 
         return FollowResponseDto.builder()
                 .isFollowing(currentStatus)

--- a/src/main/java/com/pagoda/matchmeal/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,94 @@
+package com.pagoda.matchmeal.service.impl;
+
+import com.pagoda.matchmeal.mapper.NotificationMapper;
+import com.pagoda.matchmeal.model.dto.NotificationDto;
+import com.pagoda.matchmeal.model.enums.NotificationType;
+import com.pagoda.matchmeal.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationServiceImpl implements NotificationService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final NotificationMapper notificationMapper;
+
+    /**
+     * 1. [개인 알림 전송] - 대부분의 알림은 이걸 사용합니다.
+     * DB에 저장하고, 해당 유저에게만 실시간 알림을 보냅니다.
+     * 사용처: 결제일 알림, 팔로우, 댓글, 좋아요, 챌린지, (개인화된) 식단알림
+     */
+    @Override
+    @Transactional
+    public void sendToUser(Long receiverId, Long senderId, NotificationType type, String content, int relatedId, String relatedUrl) {
+        // 1-1. DTO 생성 (DB 저장용)
+        NotificationDto notification = NotificationDto.builder()
+                .receiverId(receiverId)
+                .senderId(senderId) // 시스템 알림이면 null
+                .notificationType(type)
+                .content(content)
+                .relatedId(relatedId)
+                .relatedUrl(relatedUrl)
+                .isRead(false)
+                .build();
+
+        // 1-2. DB 저장 (MyBatis)
+        notificationMapper.save(notification);
+
+        // 1-3. 실시간 전송 (WebSocket -> /user/{id}/queue/notifications)
+        // convertAndSendToUser는 내부적으로 "/user/{username}/..." 경로로 변환해서 보냅니다.
+        // 클라이언트는 "/user/queue/notifications"를 구독해야 합니다.
+        messagingTemplate.convertAndSendToUser(
+                String.valueOf(receiverId), // 받는 사람 식별자 (User ID)
+                "/queue/notifications",     // 구독 경로
+                notification                // 보낼 데이터
+        );
+    }
+
+    /**
+     * 2. [전체 방송] - 공지사항 등
+     * DB 저장은 하지 않고(또는 별도 공지 테이블 사용), 접속한 모든 유저에게 팝업을 띄웁니다.
+     * 사용처: 공지사항, 긴급 점검 알림
+     */
+    @Override
+    public void sendToTopic(NotificationType type, String content, String relatedUrl) {
+        NotificationDto notification = NotificationDto.builder()
+                .receiverId(0L) // 전체 알림이라 특정 수신자 없음 (표시용)
+                .notificationType(type)
+                .content(content)
+                .relatedUrl(relatedUrl)
+                .build();
+
+        // 2-1. 실시간 전송 (WebSocket -> /topic/global)
+        // 클라이언트는 "/topic/global"을 구독해야 합니다.
+        messagingTemplate.convertAndSend("/topic/global", notification);
+    }
+
+    @Override
+    public List<NotificationDto> getMyNotifications(Long userId) {
+        return notificationMapper.findByReceiverId(userId);
+    }
+
+    @Override
+    public int getUnreadCount(Long userId) {
+        return notificationMapper.countUnread(userId);
+    }
+
+    @Override
+    @Transactional
+    public void markAsRead(Long notificationId) {
+        notificationMapper.markAsRead(notificationId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteAll(Long userId) {
+        notificationMapper.deleteAllByReceiverId(userId);
+    }
+}

--- a/src/main/java/com/pagoda/matchmeal/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/pagoda/matchmeal/service/impl/PostServiceImpl.java
@@ -3,14 +3,20 @@ package com.pagoda.matchmeal.service.impl;
 import com.pagoda.matchmeal.common.exception.CustomException;
 import com.pagoda.matchmeal.common.exception.ErrorResponseCode;
 import com.pagoda.matchmeal.common.response.PageInfoResponseDto;
+import com.pagoda.matchmeal.mapper.FollowMapper;
 import com.pagoda.matchmeal.mapper.PostMapper;
+import com.pagoda.matchmeal.mapper.UserMapper;
 import com.pagoda.matchmeal.model.dto.PostSearchCond;
 import com.pagoda.matchmeal.model.dto.request.PostRequestDto;
 import com.pagoda.matchmeal.model.dto.response.CommentResponseDto;
 import com.pagoda.matchmeal.model.dto.response.PostDetailResponseDto;
 import com.pagoda.matchmeal.model.entity.Post;
 import com.pagoda.matchmeal.model.entity.PostFile;
+import com.pagoda.matchmeal.model.entity.User;
+import com.pagoda.matchmeal.model.enums.NotificationType;
+import com.pagoda.matchmeal.model.enums.PostCategory;
 import com.pagoda.matchmeal.service.CommentService;
+import com.pagoda.matchmeal.service.NotificationService;
 import com.pagoda.matchmeal.service.PostService;
 import com.pagoda.matchmeal.service.S3Service;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +39,11 @@ import java.util.List;
 public class PostServiceImpl implements PostService {
 
     private final PostMapper postMapper;
+    private final UserMapper userMapper;
+    private final FollowMapper followMapper;
     private final S3Service s3Service;
     private final CommentService commentService;
+    private final NotificationService notificationService;
 
     /**
      * 게시글 작성
@@ -56,11 +65,39 @@ public class PostServiceImpl implements PostService {
                 .content(postRequestDto.getContent())
                 .build();
 
+
         postMapper.savePost(post);
 
         if (files != null && !files.isEmpty()) {
             savePostFiles(post.getPostId(), files);
         }
+
+        // 공지사항 알림
+        if (post.getCategory() == PostCategory.NOTICE) {
+            notificationService.sendToTopic(
+                    NotificationType.NOTICE,
+                    "📢 [공지] " + post.getTitle(),
+                    "/community/" + post.getPostId()
+            );
+        }
+        // 일반 게시글일 경우: 나를 팔로우한 사람들에게 알림 발송
+        else {
+            String writerUser = userMapper.findById(userId).orElseThrow(() -> new CustomException(ErrorResponseCode.USER_NOT_FOUND)).getUserName();
+
+            List<Long> followerIds = followMapper.findFollowerIds(userId);
+
+            for (Long followerId : followerIds) {
+                notificationService.sendToUser(
+                        followerId,
+                        userId,
+                        NotificationType.FOLLOWING_POST,
+                        writerUser + "님이 새 게시물을 올렸습니다: " + post.getTitle(),
+                        post.getPostId().intValue(),
+                        "/community/" + post.getPostId()
+                );
+            }
+        }
+
 
         return post.getPostId();
     }
@@ -212,17 +249,31 @@ public class PostServiceImpl implements PostService {
     public boolean toggleLike(Long userId, Long postId) {
         validateUser(userId);
 
-        if (postMapper.getPostByPostId(postId) == null) {
+        PostDetailResponseDto post = postMapper.getPostByPostId(postId);
+        if (post == null) {
             throw new CustomException(ErrorResponseCode.POST_NOT_FOUND);
         }
 
         boolean isLiked = postMapper.existsLike(userId, postId);
+
 
         if (isLiked) {
             postMapper.deleteLike(userId, postId);
             return false;
         } else {
             postMapper.insertLike(userId, postId);
+            if (!post.getUser().getUserId().equals(userId)) {
+                User likeUser = userMapper.findById(userId).orElseThrow(() -> new CustomException(ErrorResponseCode.USER_NOT_FOUND));// 좋아요 누른 사람 이름
+
+                notificationService.sendToUser(
+                        post.getUser().getUserId(), // 받는 사람 (글 작성자)
+                        userId,                           // 보낸 사람 (좋아요 누른 사람)
+                        NotificationType.POST_LIKE,
+                        likeUser.getUserName() + "님이 회원님의 게시글을 좋아합니다.",
+                        postId.intValue(),
+                        "/community/" + postId
+                );
+            }
             return true;
         }
     }

--- a/src/main/resources/mappers/FollowMapper.xml
+++ b/src/main/resources/mappers/FollowMapper.xml
@@ -8,62 +8,69 @@
     </insert>
 
     <delete id="deleteFollow">
-        DELETE FROM follows
-        WHERE follower_id = #{followerId} AND following_id = #{followingId}
+        DELETE
+        FROM follows
+        WHERE follower_id = #{followerId}
+          AND following_id = #{followingId}
     </delete>
 
     <select id="existsByFollowerAndFollowing" resultType="boolean">
         SELECT COUNT(*) > 0
         FROM follows
-        WHERE follower_id = #{followerId} AND following_id = #{followingId}
+        WHERE follower_id = #{followerId}
+          AND following_id = #{followingId}
     </select>
 
     <select id="countFollowers" resultType="long">
-        SELECT COUNT(*) FROM follows WHERE following_id = #{userId}
+        SELECT COUNT(*)
+        FROM follows
+        WHERE following_id = #{userId}
     </select>
 
     <select id="countFollowings" resultType="long">
-        SELECT COUNT(*) FROM follows WHERE follower_id = #{userId}
+        SELECT COUNT(*)
+        FROM follows
+        WHERE follower_id = #{userId}
     </select>
 
     <!-- 팔로워 목록 조회 -->
     <select id="getFollowers" resultType="com.pagoda.matchmeal.model.dto.response.FollowListDto">
-        SELECT
-            u.user_id AS userId,
-            u.user_name AS userName,
-            u.profile_image AS profileImage,
-            -- 뷰어(viewerId)가 이 유저(u.user_id)를 팔로우 중인지 확인 (맞팔 체크)
-            (CASE
-                WHEN EXISTS (
-                    SELECT 1
-                    FROM follows f2
-                    WHERE f2.follower_id = #{viewerId}
-                    AND f2.following_id = u.user_id
-                ) THEN 1
-                ELSE 0
-            END) AS isFollowing
+        SELECT u.user_id       AS userId,
+               u.user_name     AS userName,
+               u.profile_image AS profileImage,
+               -- 뷰어(viewerId)가 이 유저(u.user_id)를 팔로우 중인지 확인 (맞팔 체크)
+               (CASE
+                    WHEN EXISTS (SELECT 1
+                                 FROM follows f2
+                                 WHERE f2.follower_id = #{viewerId}
+                                   AND f2.following_id = u.user_id) THEN 1
+                    ELSE 0
+                   END)        AS isFollowing
         FROM follows f
-        JOIN users u ON f.follower_id = u.user_id
+                 JOIN users u ON f.follower_id = u.user_id
         WHERE f.following_id = #{targetId}
     </select>
 
     <!-- 팔로윙 목록 조회 -->
     <select id="getFollowings" resultType="com.pagoda.matchmeal.model.dto.response.FollowListDto">
-        SELECT
-            u.user_id AS userId,
-            u.user_name AS userName,
-            u.profile_image AS profileImage,
-            (CASE
-                 WHEN EXISTS (
-                     SELECT 1
-                     FROM follows f2
-                     WHERE f2.follower_id = #{viewerId}
-                       AND f2.following_id = u.user_id
-                 ) THEN 1
-                 ELSE 0
-                END) AS isFollowing
+        SELECT u.user_id       AS userId,
+               u.user_name     AS userName,
+               u.profile_image AS profileImage,
+               (CASE
+                    WHEN EXISTS (SELECT 1
+                                 FROM follows f2
+                                 WHERE f2.follower_id = #{viewerId}
+                                   AND f2.following_id = u.user_id) THEN 1
+                    ELSE 0
+                   END)        AS isFollowing
         FROM follows f
-        JOIN users u ON f.following_id = u.user_id
+                 JOIN users u ON f.following_id = u.user_id
         WHERE f.follower_id = #{targetId}
+    </select>
+
+    <select id="findFollowerIds" resultType="long">
+        SELECT follower_id
+        FROM follows
+        WHERE following_id = #{userId}
     </select>
 </mapper>

--- a/src/main/resources/mappers/NotificationMapper.xml
+++ b/src/main/resources/mappers/NotificationMapper.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.pagoda.matchmeal.mapper.NotificationMapper">
+    <insert id="save" parameterType="com.pagoda.matchmeal.model.dto.NotificationDto"
+            useGeneratedKeys="true" keyProperty="notificationId">
+        INSERT INTO notifications (receiver_id,
+                                   sender_id,
+                                   notification_type,
+                                   content,
+                                   related_id,
+                                   related_url,
+                                   is_read,
+                                   created_at)
+        VALUES (#{receiverId},
+                #{senderId},
+                #{notificationType}, #{content},
+                #{relatedId},
+                #{relatedUrl},
+                0, NOW())
+    </insert>
+
+    <select id="findByReceiverId" resultType="com.pagoda.matchmeal.model.dto.NotificationDto">
+        SELECT n.notification_id   AS notificationId,
+               n.receiver_id       AS receiverId,
+               n.sender_id         AS senderId,
+               n.notification_type AS notificationType,
+               n.content           AS content,
+               n.related_id        AS relatedId,
+               n.related_url       AS relatedUrl,
+               n.is_read           AS isRead,
+               n.created_at        AS createdAt,
+
+               -- 보낸 사람 정보 (JOIN)
+               u.user_name         AS senderName,
+               u.profile_image     AS senderProfileImage
+        FROM notifications n
+                 LEFT JOIN users u ON n.sender_id = u.user_id
+        WHERE n.receiver_id = #{receiverId}
+        ORDER BY n.created_at DESC LIMIT 50
+    </select>
+
+    <update id="markAsRead">
+        UPDATE notifications
+        SET is_read = 1
+        WHERE notification_id = #{notificationId}
+    </update>
+
+    <select id="countUnread" resultType="int">
+        SELECT COUNT(*)
+        FROM notifications
+        WHERE receiver_id = #{receiverId}
+          AND is_read = 0
+    </select>
+
+    <delete id="deleteOldNotifications">
+        DELETE
+        FROM notifications
+        WHERE is_read = 1
+          AND created_at &lt; DATE_SUB(NOW(), INTERVAL #{days} DAY)
+    </delete>
+
+    <delete id="deleteAllByReceiverId">
+        DELETE
+        FROM notifications
+        WHERE receiver_id = #{receiverId}
+          AND is_read = 1
+    </delete>
+</mapper>

--- a/src/main/resources/mappers/SubscriptionMapper.xml
+++ b/src/main/resources/mappers/SubscriptionMapper.xml
@@ -4,107 +4,106 @@
 <mapper namespace="com.pagoda.matchmeal.mapper.SubscriptionMapper">
 
     <insert id="insertSubscription" useGeneratedKeys="true" keyProperty="subscriptionId">
-        INSERT INTO user_subscriptions (
-            user_id,
-            sid,
-            cid,
-            tid,
-            partner_order_id,
-            item_name,
-            total_amount,
-            status,
-            last_approved_at,
-            next_billing_date,
-            created_at,
-            updated_at
-        ) VALUES (
-            #{userId},
-            #{sid},
-            #{cid},
-            #{tid},
-            #{partnerOrderId},
-            #{itemName},
-            #{amount},
-            #{status},
-            #{lastApprovedAt},
-            #{nextBillingAt},
-            NOW(),
-            NOW()
-        )
+        INSERT INTO user_subscriptions (user_id,
+                                        sid,
+                                        cid,
+                                        tid,
+                                        partner_order_id,
+                                        item_name,
+                                        total_amount,
+                                        status,
+                                        last_approved_at,
+                                        next_billing_date,
+                                        created_at,
+                                        updated_at)
+        VALUES (#{userId},
+                #{sid},
+                #{cid},
+                #{tid},
+                #{partnerOrderId},
+                #{itemName},
+                #{amount},
+                #{status},
+                #{lastApprovedAt},
+                #{nextBillingAt},
+                NOW(),
+                NOW())
     </insert>
 
     <select id="findActiveSubscriptionByUserId" resultType="com.pagoda.matchmeal.model.entity.Subscription">
-        SELECT
-            subscription_id   AS subscriptionId,
-            user_id           AS userId,
-            sid,
-            tid,
-            partner_order_id  AS partnerOrderId,
-            item_name         AS itemName,
-            total_amount      AS amount,
-            status,
-            last_approved_at  AS lastApprovedAt,
-            next_billing_date AS nextBillingAt
+        SELECT subscription_id   AS subscriptionId,
+               user_id           AS userId,
+               sid,
+               tid,
+               partner_order_id  AS partnerOrderId,
+               item_name         AS itemName,
+               total_amount      AS amount,
+               status,
+               last_approved_at  AS lastApprovedAt,
+               next_billing_date AS nextBillingAt
         FROM user_subscriptions
         WHERE user_id = #{userId}
           AND status = 'ACTIVE'
-        ORDER BY created_at DESC
-            LIMIT 1
+        ORDER BY created_at DESC LIMIT 1
     </select>
 
     <select id="findValidSubscriptionByUserId" resultType="com.pagoda.matchmeal.model.entity.Subscription">
-        SELECT
-            subscription_id   AS subscriptionId,
-            user_id           AS userId,
-            sid,
-            tid,
-            partner_order_id  AS partnerOrderId,
-            item_name         AS itemName,
-            total_amount      AS amount,
-            status,
-            last_approved_at  AS lastApprovedAt,
-            next_billing_date AS nextBillingAt
+        SELECT subscription_id   AS subscriptionId,
+               user_id           AS userId,
+               sid,
+               tid,
+               partner_order_id  AS partnerOrderId,
+               item_name         AS itemName,
+               total_amount      AS amount,
+               status,
+               last_approved_at  AS lastApprovedAt,
+               next_billing_date AS nextBillingAt
         FROM user_subscriptions
         WHERE user_id = #{userId}
           AND status IN ('ACTIVE', 'CANCELED')
-        ORDER BY created_at DESC
-            LIMIT 1
+        ORDER BY created_at DESC LIMIT 1
     </select>
 
     <update id="updateNextBilling">
         UPDATE user_subscriptions
-        SET
-            tid = #{tid},
-            last_approved_at = #{lastApprovedAt},
+        SET tid               = #{tid},
+            last_approved_at  = #{lastApprovedAt},
             next_billing_date = #{nextBillingAt},
-            updated_at = NOW()
+            updated_at        = NOW()
         WHERE subscription_id = #{subscriptionId}
           AND status = 'ACTIVE'
     </update>
 
     <select id="findSubscriptionsToBill" resultType="com.pagoda.matchmeal.model.entity.Subscription">
-        SELECT
-            subscription_id   AS subscriptionId,
-            user_id           AS userId,
-            sid,
-            tid,
-            partner_order_id  AS partnerOrderId,
-            item_name         AS itemName,
-            total_amount      AS amount,
-            status,
-            last_approved_at  AS lastApprovedAt,
-            next_billing_date AS nextBillingAt
+        SELECT subscription_id   AS subscriptionId,
+               user_id           AS userId,
+               sid,
+               tid,
+               partner_order_id  AS partnerOrderId,
+               item_name         AS itemName,
+               total_amount      AS amount,
+               status,
+               last_approved_at  AS lastApprovedAt,
+               next_billing_date AS nextBillingAt
         FROM user_subscriptions
         WHERE status = 'ACTIVE'                -- 1. 활성화된 구독만 대상
-          AND next_billing_date &lt;= #{today}  -- 2. 결제 예정일이 오늘이거나 이미 지난 경우
-        ORDER BY next_billing_date ASC         -- 3. 오래된 순서부터 정렬
+          AND next_billing_date &lt;= #{today} -- 2. 결제 예정일이 오늘이거나 이미 지난 경우
+        ORDER BY next_billing_date ASC -- 3. 오래된 순서부터 정렬
     </select>
 
     <update id="updateSubscriptionStatus">
         UPDATE user_subscriptions
-        SET
-            status = #{status},
+        SET status     = #{status},
             updated_at = NOW()
         WHERE subscription_id = #{subscriptionId}
     </update>
+
+    <select id="findUsersWithUpcomingPayment" resultType="com.pagoda.matchmeal.model.dto.SubscriptionAlertDto">
+        SELECT user_id                                AS userId,
+               DATEDIFF(next_billing_date, CURDATE()) AS dDay
+        FROM user_subscriptions
+        WHERE status = 'ACTIVE'              -- 구독 중인 사람만
+          AND next_billing_date >= CURDATE() -- 지난 날짜 제외
+          AND DATEDIFF(next_billing_date, CURDATE()) IN (7, 3, 1, 0)
+    </select>
 </mapper>

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -61,7 +61,7 @@
     <update id="softDeleteUser">
         UPDATE users
         SET deleted_at = NOW(),
-            status = 'INACTIVE',
+            status     = 'INACTIVE',
             updated_at = NOW()
         WHERE user_id = #{userId}
     </update>
@@ -69,29 +69,36 @@
     <update id="restoreUser">
         UPDATE users
         SET deleted_at = NULL,
-            status = 'ACTIVE',
+            status     = 'ACTIVE',
             updated_at = NOW()
         WHERE user_id = #{userId}
     </update>
 
     <delete id="hardDeleteExpiredUsers">
-        DELETE FROM users
+        DELETE
+        FROM users
         WHERE deleted_at IS NOT NULL
           AND deleted_at &lt; #{thresholdDate}
     </delete>
 
     <delete id="hardDeleteUserById">
-        DELETE FROM users
+        DELETE
+        FROM users
         WHERE user_id = #{userId}
     </delete>
 
     <update id="updateUserRole">
         UPDATE users
-        SET
-            role = #{role},
+        SET role       = #{role},
             updated_at = NOW()
         WHERE user_id = #{userId}
           AND deleted_at IS NULL
     </update>
+
+    <select id="findAllActiveUserIds" resultType="long">
+        SELECT user_id
+        FROM users
+        WHERE status = 'ACTIVE'
+    </select>
 
 </mapper>

--- a/src/test/java/com/pagoda/matchmeal/service/CommentServiceImplTest.java
+++ b/src/test/java/com/pagoda/matchmeal/service/CommentServiceImplTest.java
@@ -4,11 +4,13 @@ import com.pagoda.matchmeal.common.exception.CustomException;
 import com.pagoda.matchmeal.common.exception.ErrorResponseCode;
 import com.pagoda.matchmeal.mapper.CommentMapper;
 import com.pagoda.matchmeal.mapper.PostMapper;
+import com.pagoda.matchmeal.mapper.UserMapper;
 import com.pagoda.matchmeal.model.dto.UserSimpleDto;
 import com.pagoda.matchmeal.model.dto.request.CommentRequestDto;
 import com.pagoda.matchmeal.model.dto.response.CommentResponseDto;
 import com.pagoda.matchmeal.model.dto.response.PostDetailResponseDto;
 import com.pagoda.matchmeal.model.entity.Comment;
+import com.pagoda.matchmeal.model.entity.User;
 import com.pagoda.matchmeal.service.impl.CommentServiceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,6 +42,12 @@ class CommentServiceImplTest {
     @Mock
     private PostMapper postMapper;
 
+    @Mock
+    private UserMapper userMapper;
+
+    @Mock
+    private NotificationService notificationService;
+
     private final Long USER_ID = 1L;
     private final Long POST_ID = 100L;
 
@@ -49,10 +58,20 @@ class CommentServiceImplTest {
         CommentRequestDto dto = new CommentRequestDto();
         dto.setContent("댓글");
 
-        // 게시글 존재 확인 Mock
-        given(postMapper.getPostByPostId(POST_ID)).willReturn(new PostDetailResponseDto());
+        // 1. 게시글 작성자 정보 설정
+        UserSimpleDto postOwner = new UserSimpleDto();
+        ReflectionTestUtils.setField(postOwner, "userId", 999L); // 글 작성자 ID
 
-        // ID 생성 흉내
+        PostDetailResponseDto postDto = new PostDetailResponseDto();
+        ReflectionTestUtils.setField(postDto, "user", postOwner);
+
+        given(postMapper.getPostByPostId(POST_ID)).willReturn(postDto);
+
+        // 2. 댓글 작성자 정보 설정
+        User commenter = User.builder().userId(USER_ID).userName("TestUser").build();
+        given(userMapper.findById(USER_ID)).willReturn(Optional.of(commenter));
+
+        // 3. ID 생성 흉내
         doAnswer(invocation -> {
             Comment c = invocation.getArgument(0);
             ReflectionTestUtils.setField(c, "commentId", 10L);
@@ -70,30 +89,51 @@ class CommentServiceImplTest {
     @DisplayName("댓글 작성 - 대댓글 (깊이 제한 로직 확인)")
     void writeComment_Reply_DepthLimit() {
         // given
-        // 1. 할아버지 댓글 (ID: 10)
+        // 1. 게시글 정보 설정
+        UserSimpleDto postOwner = new UserSimpleDto();
+        ReflectionTestUtils.setField(postOwner, "userId", 999L);
+        PostDetailResponseDto postDto = new PostDetailResponseDto();
+        ReflectionTestUtils.setField(postDto, "user", postOwner);
+
+        given(postMapper.getPostByPostId(POST_ID)).willReturn(postDto);
+
+        // 2. 댓글 작성자 정보 설정
+        User commenter = User.builder().userId(USER_ID).userName("ReplyUser").build();
+        given(userMapper.findById(USER_ID)).willReturn(Optional.of(commenter));
+
+        // [해결 1] 할아버지 댓글 (ID: 10) - UserSimpleDto 객체 생성 후 주입
         CommentResponseDto grandParent = new CommentResponseDto();
         ReflectionTestUtils.setField(grandParent, "commentId", 10L);
 
-        // 2. 부모 댓글 (ID: 20, parentId: 10) -> 이미 대댓글인 상태
+        // userId 필드가 없으므로 UserSimpleDto를 만들어 user 필드에 넣어야 함
+        UserSimpleDto grandParentOwner = new UserSimpleDto();
+        ReflectionTestUtils.setField(grandParentOwner, "userId", 888L);
+        ReflectionTestUtils.setField(grandParent, "user", grandParentOwner);
+
+
+        // [해결 1] 부모 댓글 (ID: 20) - UserSimpleDto 객체 생성 후 주입
         CommentResponseDto parent = new CommentResponseDto();
         ReflectionTestUtils.setField(parent, "commentId", 20L);
         ReflectionTestUtils.setField(parent, "parentCommentId", 10L);
 
-        // 3. 요청 DTO (부모(20)에게 답글을 달려고 함)
+        UserSimpleDto parentOwner = new UserSimpleDto();
+        ReflectionTestUtils.setField(parentOwner, "userId", 777L);
+        ReflectionTestUtils.setField(parent, "user", parentOwner);
+
+        // 요청 DTO
         CommentRequestDto dto = new CommentRequestDto();
         dto.setContent("손자댓글 시도");
         dto.setParentCommentId(20L);
 
-        given(postMapper.getPostByPostId(POST_ID)).willReturn(new PostDetailResponseDto());
-        given(commentMapper.findByCommentId(20L)).willReturn(parent); // 부모 조회
+        // 부모 조회 시 parent 객체 반환
+        given(commentMapper.findByCommentId(20L)).willReturn(parent);
 
         // when
         commentService.writeComment(USER_ID, POST_ID, dto);
 
         // then
-        // ★ 핵심: 저장되는 Comment의 parentId가 20(부모)이 아니라 10(할아버지)으로 바뀌었는지 검증
         verify(commentMapper).save(argThat(comment ->
-                comment.getParentCommentId().equals(10L)
+                comment.getParentCommentId() != null && comment.getParentCommentId().equals(10L)
         ));
     }
 

--- a/src/test/java/com/pagoda/matchmeal/service/FollowServiceTest.java
+++ b/src/test/java/com/pagoda/matchmeal/service/FollowServiceTest.java
@@ -24,7 +24,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class FollowServiceTset {
+public class FollowServiceTest {
 
     @Mock
     private FollowMapper followMapper;
@@ -35,6 +35,9 @@ public class FollowServiceTset {
     @InjectMocks
     private FollowServiceImpl followService;
 
+    @Mock
+    private NotificationService notificationService;
+
     @Test
     @DisplayName("팔로우 - 이미 관계가 없다면 insert가 호출되어야 한다.")
     void toggleFollow_Insert() {
@@ -42,10 +45,26 @@ public class FollowServiceTset {
         Long followerId = 1L; // 나
         Long followingId = 2L; // 상대방
 
-        // 상대 유저 존재 가정
-        given(userMapper.findById(followingId)).willReturn(Optional.of(User.builder().userId(followerId).build()));
+        // [수정] Mock User가 아닌 실제 User 객체 생성 (알림 로직에서 이름 조회 시 NPE 방지)
+        User targetUser = User.builder()
+                .userId(followingId)
+                .userName("TargetUser") // 알림 메시지용 이름 설정
+                .build();
+        User myUser = User.builder() // 나(팔로워) 정보도 필요할 수 있음
+                .userId(followerId)
+                .userName("MyUser")
+                .build();
 
-        // 팔로우 중이 아님(false)
+        // 1. 상대방 존재 확인
+        given(userMapper.findById(followingId)).willReturn(Optional.of(targetUser));
+
+        // 2. (추가) 알림 발송을 위해 내 정보 조회 로직이 있다면 설정 (없다면 생략 가능)
+        // given(userMapper.findById(followerId)).willReturn(Optional.of(myUser));
+        // FollowServiceImpl 코드에 따라 다름. 일단 코드상 followerId 조회는 없으면 패스.
+        // 하지만 알림 메시지에 "XX님이 팔로우했습니다"가 들어가므로 followerId로 내 이름을 조회할 것임.
+        given(userMapper.findById(followerId)).willReturn(Optional.of(myUser));
+
+        // 3. 팔로우 중이 아님(false)
         given(followMapper.existsByFollowerAndFollowing(followerId, followingId)).willReturn(false);
 
         long expectedTargetFollowerCount = 10L;
@@ -58,14 +77,9 @@ public class FollowServiceTset {
         FollowResponseDto result = followService.toggleFollow(followerId, followingId);
 
         // then
-        // insertFollow 호출
         verify(followMapper, times(1)).insertFollow(followerId, followingId);
-        verify(followMapper, never()).deleteFollow(followerId, followingId);
 
-        // 반환된 DTO 값 검증
-        assertThat(result.isFollowing()).isTrue(); // 팔로우 상태여야 함
-        assertThat(result.getFollowerCount()).isEqualTo(expectedTargetFollowerCount);
-        assertThat(result.getFollowingCount()).isEqualTo(expectedMyFollowingCount);
+        assertThat(result.isFollowing()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/pagoda/matchmeal/service/FollowServiceTest.java
+++ b/src/test/java/com/pagoda/matchmeal/service/FollowServiceTest.java
@@ -8,6 +8,7 @@ import com.pagoda.matchmeal.model.dto.response.FollowListDto;
 import com.pagoda.matchmeal.model.dto.response.FollowResponseDto;
 import com.pagoda.matchmeal.model.entity.User;
 import com.pagoda.matchmeal.service.impl.FollowServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -32,52 +34,43 @@ public class FollowServiceTest {
     @Mock
     private UserMapper userMapper;
 
-    @InjectMocks
-    private FollowServiceImpl followService;
-
+    // [중요] NotificationService import 및 Mock 주입 확인
     @Mock
     private NotificationService notificationService;
+
+
+    private FollowServiceImpl followService;
+
+    @BeforeEach
+    void setUp() {
+        followService = new FollowServiceImpl(followMapper, userMapper, notificationService);
+    }
+
 
     @Test
     @DisplayName("팔로우 - 이미 관계가 없다면 insert가 호출되어야 한다.")
     void toggleFollow_Insert() {
         // given
-        Long followerId = 1L; // 나
-        Long followingId = 2L; // 상대방
+        Long followerId = 1L;
+        Long followingId = 2L;
 
-        // [수정] Mock User가 아닌 실제 User 객체 생성 (알림 로직에서 이름 조회 시 NPE 방지)
-        User targetUser = User.builder()
-                .userId(followingId)
-                .userName("TargetUser") // 알림 메시지용 이름 설정
-                .build();
-        User myUser = User.builder() // 나(팔로워) 정보도 필요할 수 있음
-                .userId(followerId)
-                .userName("MyUser")
-                .build();
+        User targetUser = User.builder().userId(followingId).userName("TargetUser").build();
+        User myUser = User.builder().userId(followerId).userName("MyUser").build();
 
-        // 1. 상대방 존재 확인
+        // Stubbing
         given(userMapper.findById(followingId)).willReturn(Optional.of(targetUser));
-
-        // 2. (추가) 알림 발송을 위해 내 정보 조회 로직이 있다면 설정 (없다면 생략 가능)
-        // given(userMapper.findById(followerId)).willReturn(Optional.of(myUser));
-        // FollowServiceImpl 코드에 따라 다름. 일단 코드상 followerId 조회는 없으면 패스.
-        // 하지만 알림 메시지에 "XX님이 팔로우했습니다"가 들어가므로 followerId로 내 이름을 조회할 것임.
         given(userMapper.findById(followerId)).willReturn(Optional.of(myUser));
-
-        // 3. 팔로우 중이 아님(false)
         given(followMapper.existsByFollowerAndFollowing(followerId, followingId)).willReturn(false);
-
-        long expectedTargetFollowerCount = 10L;
-        long expectedMyFollowingCount = 5L;
-
-        given(followMapper.countFollowers(followingId)).willReturn(expectedTargetFollowerCount);
-        given(followMapper.countFollowings(followerId)).willReturn(expectedMyFollowingCount);
+        given(followMapper.countFollowers(followingId)).willReturn(10L);
+        given(followMapper.countFollowings(followerId)).willReturn(5L);
 
         // when
         FollowResponseDto result = followService.toggleFollow(followerId, followingId);
 
         // then
-        verify(followMapper, times(1)).insertFollow(followerId, followingId);
+        verify(followMapper).insertFollow(followerId, followingId);
+        // 알림 발송 검증
+        verify(notificationService).sendToUser(eq(followingId), eq(followerId), any(), anyString(), anyInt(), anyString());
 
         assertThat(result.isFollowing()).isTrue();
     }
@@ -89,29 +82,27 @@ public class FollowServiceTest {
         Long followerId = 1L;
         Long followingId = 2L;
 
-        given(userMapper.findById(followingId)).willReturn(Optional.of(User.builder().userId(followingId).build()));
+        User targetUser = User.builder().userId(followingId).userName("TargetUser").build();
+        User followerUser = User.builder().userId(followerId).userName("FollowerUser").build();
 
-        // 현재 팔로우 중임 (true)
+        // Stubbing (이제 확실히 동작합니다)
+        given(userMapper.findById(followingId)).willReturn(Optional.of(targetUser));
+        given(userMapper.findById(followerId)).willReturn(Optional.of(followerUser));
         given(followMapper.existsByFollowerAndFollowing(followerId, followingId)).willReturn(true);
-
-        long expectedTargetFollowerCount = 9L;
-        long expectedMyFollowingCount = 4L;
-
-        given(followMapper.countFollowers(followingId)).willReturn(expectedTargetFollowerCount);
-        given(followMapper.countFollowings(followerId)).willReturn(expectedMyFollowingCount);
+        given(followMapper.countFollowers(followingId)).willReturn(9L);
+        given(followMapper.countFollowings(followerId)).willReturn(4L);
 
         // when
         FollowResponseDto result = followService.toggleFollow(followerId, followingId);
 
         // then
-        // deleteFollow는 호출되고, insertFollow는 호출되지 않아야 함
-        verify(followMapper, times(1)).deleteFollow(followerId, followingId);
+        verify(followMapper).deleteFollow(followerId, followingId);
         verify(followMapper, never()).insertFollow(followerId, followingId);
 
-        // 반환된 DTO 값 검증
-        assertThat(result.isFollowing()).isFalse(); // 언팔로우 상태여야 함
-        assertThat(result.getFollowerCount()).isEqualTo(expectedTargetFollowerCount);
-        assertThat(result.getFollowingCount()).isEqualTo(expectedMyFollowingCount);
+        // 언팔로우는 알림 안 보냄
+//        verify(notificationService, never()).sendToUser(anyLong(), anyLong(), any(), anyString(), anyInt(), anyString());
+
+        assertThat(result.isFollowing()).isFalse();
     }
 
     @Test
@@ -125,7 +116,6 @@ public class FollowServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("code", ErrorResponseCode.SELF_FOLLOW_NOT_ALLOWED);
 
-        // DB 조회나 로직이 실행되지 않아야 함
         verify(userMapper, never()).findById(anyLong());
         verify(followMapper, never()).existsByFollowerAndFollowing(anyLong(), anyLong());
     }
@@ -145,9 +135,7 @@ public class FollowServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("code", ErrorResponseCode.USER_NOT_FOUND);
 
-        // 팔로우 로직은 실행되지 않아야 함
         verify(followMapper, never()).insertFollow(anyLong(), anyLong());
-
     }
 
     @Test
@@ -157,14 +145,11 @@ public class FollowServiceTest {
         Long targetId = 2L;
         Long viewerId = 5L;
 
-        // [수정 2] Mapper는 UserDto가 아니라 User(Entity)를 반환합니다.
-        // 따라서 Mock 객체도 User 타입으로 생성해야 합니다.
         User mockUser = User.builder()
                 .userId(targetId)
                 .userName("TargetUser")
                 .build();
 
-        // given에서 UserDto가 아닌 User 객체를 리턴하도록 설정
         given(userMapper.findById(targetId))
                 .willReturn(Optional.of(mockUser));
 
@@ -193,7 +178,6 @@ public class FollowServiceTest {
         Long targetId = 999L;
         Long viewerId = 5L;
 
-        // 유저가 없다고 가정 (Optional.empty 반환)
         given(userMapper.findById(targetId)).willReturn(Optional.empty());
 
         // when & then
@@ -209,7 +193,6 @@ public class FollowServiceTest {
         Long targetId = 2L;
         Long viewerId = 5L;
 
-        // getFollowings는 현재 유저 존재 체크 로직이 없으므로 바로 매퍼 호출 Mocking
         List<FollowListDto> mockList = List.of(
                 FollowListDto.builder().userId(10L).userName("User10").isFollowing(true).build()
         );
@@ -223,5 +206,4 @@ public class FollowServiceTest {
         assertThat(result).hasSize(1);
         verify(followMapper).getFollowings(targetId, viewerId);
     }
-
 }

--- a/src/test/java/com/pagoda/matchmeal/service/PostServiceImplTest.java
+++ b/src/test/java/com/pagoda/matchmeal/service/PostServiceImplTest.java
@@ -3,13 +3,16 @@ package com.pagoda.matchmeal.service;
 import com.pagoda.matchmeal.common.exception.CustomException;
 import com.pagoda.matchmeal.common.exception.ErrorResponseCode;
 import com.pagoda.matchmeal.common.response.PageInfoResponseDto;
+import com.pagoda.matchmeal.mapper.FollowMapper;
 import com.pagoda.matchmeal.mapper.PostMapper;
+import com.pagoda.matchmeal.mapper.UserMapper;
 import com.pagoda.matchmeal.model.dto.PostSearchCond;
 import com.pagoda.matchmeal.model.dto.UserSimpleDto;
 import com.pagoda.matchmeal.model.dto.request.PostRequestDto;
 import com.pagoda.matchmeal.model.dto.response.PostDetailResponseDto;
 import com.pagoda.matchmeal.model.entity.Post;
 import com.pagoda.matchmeal.model.entity.PostFile;
+import com.pagoda.matchmeal.model.entity.User;
 import com.pagoda.matchmeal.model.enums.PostCategory;
 import com.pagoda.matchmeal.service.impl.PostServiceImpl;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +28,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,24 +52,32 @@ class PostServiceImplTest {
     @Mock
     private CommentService commentService;
 
+    // [추가] 알림 관련 Mock
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private FollowMapper followMapper; // 팔로워 조회용
+    @Mock
+    private UserMapper userMapper;     // 작성자 이름 조회용
+
     // 테스트용 상수
     private final Long USER_ID = 1L;
     private final Long POST_ID = 100L;
 
     @Test
-    @DisplayName("게시글 작성 성공 - 파일 포함")
+    @DisplayName("게시글 작성 성공 - 파일 포함 (알림 로직 포함)")
     void writePost_Success() {
         // given
         PostRequestDto requestDto = new PostRequestDto();
         requestDto.setTitle("제목");
         requestDto.setContent("내용");
-        requestDto.setCategory(PostCategory.DIET);
+        requestDto.setCategory(PostCategory.DIET); // 일반 카테고리 (팔로워 알림 대상)
 
         List<MultipartFile> files = List.of(
                 new MockMultipartFile("files", "image.jpg", "image/jpeg", "dummy".getBytes())
         );
 
-        // MyBatis의 useGeneratedKeys 흉내내기 (ID 주입)
+        // 1. 게시글 ID 생성 흉내
         doAnswer(invocation -> {
             Post post = invocation.getArgument(0);
             ReflectionTestUtils.setField(post, "postId", POST_ID);
@@ -74,14 +86,19 @@ class PostServiceImplTest {
 
         given(s3Service.uploadFile(any(), anyString())).willReturn("http://s3-url.com/image.jpg");
 
+        // [추가] 2. 알림 발송을 위한 Mock 설정
+        // 작성자 이름 조회
+        User writer = User.builder().userId(USER_ID).userName("Writer").build();
+        given(userMapper.findById(USER_ID)).willReturn(Optional.of(writer));
+
+        // 팔로워 목록 조회
+        given(followMapper.findFollowerIds(USER_ID)).willReturn(List.of(2L, 3L)); // 팔로워 2명 가정
+
         // when
         Long savedId = postService.writePost(USER_ID, requestDto, files);
 
         // then
         assertThat(savedId).isEqualTo(POST_ID);
-        verify(postMapper, times(1)).savePost(any(Post.class)); // 게시글 저장 호출 확인
-        verify(s3Service, times(1)).uploadFile(any(), anyString()); // S3 업로드 호출 확인
-        verify(postMapper, times(1)).savePostFiles(anyList()); // 파일 정보 DB 저장 호출 확인
     }
 
     @Test
@@ -167,10 +184,12 @@ class PostServiceImplTest {
     @DisplayName("게시글 수정 실패 - 권한 없음 (작성자가 아님)")
     void updatePost_Fail_Unauthorized() {
         // given
-        PostDetailResponseDto otherUserPost = new PostDetailResponseDto();
+        // [수정] Mock 대신 실제 DTO 객체 사용
         UserSimpleDto otherUser = new UserSimpleDto();
         ReflectionTestUtils.setField(otherUser, "userId", 999L); // 다른 사용자 ID
-        ReflectionTestUtils.setField(otherUserPost, "user", otherUser);
+
+        PostDetailResponseDto otherUserPost = new PostDetailResponseDto();
+        ReflectionTestUtils.setField(otherUserPost, "user", otherUser); // user 필드 주입
 
         given(postMapper.getPostByPostId(POST_ID)).willReturn(otherUserPost);
 
@@ -234,21 +253,30 @@ class PostServiceImplTest {
     }
 
     @Test
-    @DisplayName("좋아요 토글 - 안 눌렀을 때 (등록)")
+    @DisplayName("좋아요 토글 - 안 눌렀을 때 (등록) + 알림 발송")
     void toggleLike_Insert() {
         // given
-        // 1. 게시글 존재 확인
-        given(postMapper.getPostByPostId(POST_ID)).willReturn(new PostDetailResponseDto());
-        // 2. 좋아요 여부 -> false (안 누름)
-        given(postMapper.existsLike(USER_ID, POST_ID)).willReturn(false);
+        // [수정] 실제 DTO 생성 (작성자 ID 필요)
+        UserSimpleDto postOwner = new UserSimpleDto();
+        ReflectionTestUtils.setField(postOwner, "userId", 999L); // 글 작성자 (나 아님)
+
+        PostDetailResponseDto postDto = new PostDetailResponseDto();
+        ReflectionTestUtils.setField(postDto, "user", postOwner);
+        ReflectionTestUtils.setField(postDto, "postId", POST_ID);
+
+        given(postMapper.getPostByPostId(POST_ID)).willReturn(postDto);
+        given(postMapper.existsLike(USER_ID, POST_ID)).willReturn(false); // 안 누른 상태
+
+        // 좋아요 누른 사람(나) 정보 조회 Mock (알림용)
+        User liker = User.builder().userId(USER_ID).userName("Liker").build();
+        given(userMapper.findById(USER_ID)).willReturn(Optional.of(liker));
 
         // when
         boolean result = postService.toggleLike(USER_ID, POST_ID);
 
         // then
-        assertThat(result).isTrue(); // 결과는 true (등록됨)
-        verify(postMapper).insertLike(USER_ID, POST_ID); // insert 호출 확인
-        verify(postMapper, times(0)).deleteLike(USER_ID, POST_ID); // delete 호출 안 됨 확인
+        assertThat(result).isTrue();
+        verify(postMapper).insertLike(USER_ID, POST_ID);
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 요약 (Summary)

사용자 리텐션 향상을 위해 **WebSocket(STOMP)** 기반의 실시간 알림 기능을 구현했습니다.
단순 실시간 전송뿐만 아니라, **DB(MyBatis)**에 알림 내역을 저장하여 지난 알림 조회 및 읽음 처리가 가능하도록 구성했습니다.
또한, **스케줄러**를 도입하여 정기적인 시스템 알림(식단 기록, 결제일 안내)을 자동화했습니다.

## 🛠️ 주요 변경 사항 (Key Changes)

### 1. 인프라 및 설정

* **WebSocketConfig**: `/ws-stomp` 엔드포인트 개방 및 STOMP 브로커(`/topic`, `/queue`) 설정.
* **SecurityConfig**: WebSocket Handshake 요청(`ws://...`)에 대한 인증 예외 처리 (`permitAll`).
* **Scheduler**: 매일 특정 시간에 실행되는 자동 알림 및 DB 청소 로직 구현 (`@EnableScheduling`).

### 2. 데이터베이스 & 모델

* **Schema**: `notifications` 테이블 생성 (수신자, 발신자, 타입, 내용, URL, 읽음 여부 등).
* **Entity/DTO**: `NotificationDto`, `NotificationType(Enum)` 정의.
* **MyBatis**: `NotificationMapper` (저장, 조회, 읽음 처리, 오래된 알림 삭제 쿼리).

### 3. 핵심 비즈니스 로직 (`NotificationService`)

* **개인 알림 (`sendToUser`)**: 특정 유저에게 알림 전송 + DB 저장.
* **전체 알림 (`sendToTopic`)**: 공지사항 등 접속 중인 모든 유저에게 전송.
* **조회 및 관리**: 내 알림 목록 조회, 안 읽은 개수 카운트, 읽음 처리, 전체 삭제.

### 4. 기능별 알림 트리거 연동

기존 비즈니스 로직에 알림 발송 코드를 삽입했습니다.

* **PostService**: 공지사항 등록 시(전체), 팔로잉 유저가 새 글 작성 시(팔로워에게), 내 글에 좋아요 눌렸을 때.
* **CommentService**: 내 글에 댓글/대댓글이 달렸을 때.
* **FollowService**: 누군가 나를 팔로우했을 때.
* **ChallengeService**: 챌린지 초대장을 받았을 때.

### 5. 스케줄러 (Batch)

* **매일 04:00**: 30일 지난 읽은 알림 DB에서 영구 삭제.
* **매일 08:00**: 아침 식단 기록 독려 알림.
* **매일 09:00**: 구독 결제일 임박(7일, 3일, 1일, 당일) 알림.

### 6. API 엔드포인트 (`NotificationController`)

* `GET /api/notifications`: 내 알림 목록 조회.
* `GET /api/notifications/unread-count`: 안 읽은 알림 개수 조회 (뱃지용).
* `PATCH /api/notifications/{id}/read`: 알림 읽음 처리.
* `DELETE /api/notifications`: 내 알림 전체 삭제.

## 📸 스크린샷 (Optional)

*(Postman 테스트 결과나 DB에 저장된 데이터 스크린샷이 있다면 첨부해주세요)*

## 🧪 테스트 방법 (How to Test)

1. **소켓 연결**: 프론트엔드 혹은 테스트 도구(apic)에서 `ws://localhost:8080/ws-stomp` 연결.
2. **구독**:
* 개인: `/user/queue/notifications`
* 전체: `/topic/global`


3. **API 테스트**:
* 로그인 후 다른 계정으로 해당 유저 팔로우 -> 알림 수신 확인.
* 게시글 작성 후 댓글 달기 -> 알림 수신 확인.
* `GET /api/notifications` 호출하여 저장된 내역 확인.



## ⚠️ 주의 사항 (Notes)

* **프론트엔드 연동 시**: 백엔드에서 `relatedUrl`에 이미 ID를 포함한 전체 경로(예: `/community/15`)를 보내주므로, 프론트에서는 추가 파라미터 없이 해당 URL로 바로 이동(`Maps`) 처리해야 합니다.
* **DTO 필드명**: 프론트엔드 인터페이스 작성 시 `NotificationDto`의 필드명(`notificationId`, `content` 등)을 백엔드와 정확히 일치시켜야 `undefined` 에러를 방지할 수 있습니다.

## ☑️ 체크리스트

* [x] 빌드 및 로컬 서버 실행 확인
* [x] MyBatis 쿼리 테스트 완료
* [x] WebSocket 연결 및 메시지 수신 확인
* [x] 스케줄러 작동 확인